### PR TITLE
Use code-server instead of openvscode-server; Fix 39

### DIFF
--- a/astro-default/conda-notebook-lock.yml
+++ b/astro-default/conda-notebook-lock.yml
@@ -2,15 +2,17 @@ name: notebook
 channels:
   - conda-forge
 dependencies:
+  - _libgcc_mutex=0.1=conda_forge
+  - _openmp_mutex=4.5=2_gnu
   - acstools=3.7.2=pyhd8ed1ab_1
   - affine=2.4.0=pyhd8ed1ab_1
   - aiobotocore=2.21.1=pyhd8ed1ab_0
   - aiohappyeyeballs=2.6.1=pyhd8ed1ab_0
-  - aiohttp=3.11.14=py312h178313f_0
+  - aiohttp=3.11.18=py312h178313f_0
   - aioitertools=0.12.0=pyhd8ed1ab_1
   - aiosignal=1.3.2=pyhd8ed1ab_0
-  - alembic=1.15.1=pyhd8ed1ab_0
-  - alsa-lib=1.2.13=hb9d3cd8_0
+  - alembic=1.15.2=pyhd8ed1ab_0
+  - alsa-lib=1.2.14=hb9d3cd8_0
   - annotated-types=0.7.0=pyhd8ed1ab_1
   - anyio=4.9.0=pyh29332c3_0
   - aom=3.9.1=hac33072_0
@@ -27,27 +29,27 @@ dependencies:
   - astropy=7.0.1=pyhd8ed1ab_0
   - astropy-base=7.0.1=py312hb8e8fe3_0
   - astropy-healpix=1.1.2=py312hc0a28a1_0
-  - astropy-iers-data=0.2025.3.17.0.34.53=pyhd8ed1ab_0
+  - astropy-iers-data=0.2025.5.5.0.38.14=pyhd8ed1ab_0
   - astroquery=0.4.10=pyhd8ed1ab_0
   - astroscrappy=1.2.0=py312h66e93f0_1
   - asttokens=3.0.0=pyhd8ed1ab_1
   - async-lru=2.0.5=pyh29332c3_0
   - async_generator=1.10=pyhd8ed1ab_2
   - attrs=25.3.0=pyh71513ae_0
-  - autograd=1.7.0=pyhd8ed1ab_1
-  - aws-c-auth=0.8.6=hd08a7f5_4
-  - aws-c-cal=0.8.7=h043a21b_0
-  - aws-c-common=0.12.0=hb9d3cd8_0
-  - aws-c-compression=0.3.1=h3870646_2
-  - aws-c-event-stream=0.5.4=h04a3f94_2
-  - aws-c-http=0.9.4=hb9b18c6_4
-  - aws-c-io=0.17.0=h3dad3f2_6
-  - aws-c-mqtt=0.12.2=h108da3e_2
-  - aws-c-s3=0.7.13=h822ba82_2
-  - aws-c-sdkutils=0.2.3=h3870646_2
-  - aws-checksums=0.2.3=h3870646_2
-  - aws-crt-cpp=0.31.0=h55f77e1_4
-  - aws-sdk-cpp=1.11.510=h37a5c72_3
+  - autograd=1.8.0=pyhd8ed1ab_0
+  - aws-c-auth=0.9.0=h9a6e2ae_4
+  - aws-c-cal=0.9.0=hada3f3f_0
+  - aws-c-common=0.12.2=hb9d3cd8_0
+  - aws-c-compression=0.3.1=hc2d532b_4
+  - aws-c-event-stream=0.5.4=hc5e5e9e_7
+  - aws-c-http=0.10.0=h6884c39_0
+  - aws-c-io=0.18.1=h1a9f769_2
+  - aws-c-mqtt=0.12.3=hef6a231_4
+  - aws-c-s3=0.7.16=h7dfd680_1
+  - aws-c-sdkutils=0.2.3=hc2d532b_4
+  - aws-checksums=0.2.7=hc2d532b_0
+  - aws-crt-cpp=0.32.4=h0cee55f_2
+  - aws-sdk-cpp=1.11.510=h5b777a2_6
   - azure-core-cpp=1.14.0=h5cfcd09_0
   - azure-identity-cpp=1.10.0=h113e628_0
   - azure-storage-blobs-cpp=12.13.0=h3cf044e_1
@@ -56,12 +58,12 @@ dependencies:
   - babel=2.17.0=pyhd8ed1ab_0
   - backports=1.0=pyhd8ed1ab_5
   - backports.tarfile=1.2.0=pyhd8ed1ab_1
-  - beautifulsoup4=4.13.3=pyha770c72_0
+  - beautifulsoup4=4.13.4=pyha770c72_0
   - bleach=6.2.0=pyh29332c3_4
   - bleach-with-css=6.2.0=h82add2a_4
   - blinker=1.9.0=pyhff2d567_0
   - blosc=1.21.6=he440d0b_1
-  - bokeh=3.7.0=pyhd8ed1ab_0
+  - bokeh=3.7.2=pyhd8ed1ab_1
   - boto3=1.37.1=pyhd8ed1ab_0
   - botocore=1.37.1=pyge310_1234567_0
   - bottleneck=1.4.2=py312hc0a28a1_0
@@ -71,9 +73,9 @@ dependencies:
   - brotli-python=1.1.0=py312h2ec8cdc_2
   - brunsli=0.1=h9c3ff4c_0
   - bzip2=1.0.8=h4bc722e_7
-  - c-ares=1.34.4=hb9d3cd8_0
+  - c-ares=1.34.5=hb9d3cd8_0
   - c-blosc2=2.15.2=h3122c55_1
-  - ca-certificates=2025.1.31=hbcca054_0
+  - ca-certificates=2025.4.26=hbd8a1cb_0
   - cached-property=1.5.2=hd8ed1ab_1
   - cached_property=1.5.2=pyha770c72_1
   - cairo=1.18.4=h3394656_0
@@ -81,39 +83,40 @@ dependencies:
   - cdshealpix=0.7.1=py312h12e396e_2
   - ceres-solver=2.2.0=h417fa77_5
   - certifi=2025.1.31=pyhd8ed1ab_0
-  - certipy=0.2.1=pyhd8ed1ab_1
+  - certipy=0.2.2=pyhd8ed1ab_0
   - cffi=1.17.1=py312h06ac9bb_0
-  - cfitsio=4.5.0=h44b4e7a_0
+  - cfitsio=4.6.2=h44b4e7a_0
   - charls=2.4.2=h59595ed_0
-  - charset-normalizer=3.4.1=pyhd8ed1ab_0
+  - charset-normalizer=3.4.2=pyhd8ed1ab_0
   - click=8.1.8=pyh707e725_0
   - click-plugins=1.1.1=pyhd8ed1ab_1
   - cligj=0.7.2=pyhd8ed1ab_2
   - cloudpickle=3.1.1=pyhd8ed1ab_0
+  - code-server=4.99.4=h59d26c6_0
   - colorama=0.4.6=pyhd8ed1ab_1
   - comm=0.2.2=pyhd8ed1ab_1
-  - configurable-http-proxy=4.6.2=he2f69ee_0
-  - contourpy=1.3.1=py312h68727a3_0
-  - cryptography=44.0.2=py312hda17c39_0
+  - configurable-http-proxy=4.6.3=h92b4e83_0
+  - contourpy=1.3.2=py312h68727a3_0
+  - cryptography=44.0.3=py312hda17c39_0
   - cycler=0.12.1=pyhd8ed1ab_1
   - cyrus-sasl=2.1.27=h54b06d7_7
   - cython=3.0.12=py312h2614dfc_0
   - cytoolz=1.0.1=py312h66e93f0_0
-  - dask=2025.2.0=pyhd8ed1ab_0
-  - dask-core=2025.2.0=pyhd8ed1ab_0
+  - dask=2025.4.1=pyhd8ed1ab_0
+  - dask-core=2025.4.1=pyhd8ed1ab_0
   - dask-labextension=7.0.0=pyhd8ed1ab_1
   - dav1d=1.2.1=hd590300_0
   - dbus=1.13.6=h5008d03_3
-  - debugpy=1.8.13=py312h2ec8cdc_0
+  - debugpy=1.8.14=py312h2ec8cdc_0
   - decorator=5.2.1=pyhd8ed1ab_0
   - defusedxml=0.7.1=pyhd8ed1ab_0
   - deprecated=1.2.18=pyhd8ed1ab_0
-  - distributed=2025.2.0=pyhd8ed1ab_0
+  - distributed=2025.4.1=pyhd8ed1ab_0
   - double-conversion=3.3.1=h5888daf_0
   - eigen=3.4.0=h00ab1b0_0
   - exceptiongroup=1.2.2=pyhd8ed1ab_1
-  - executing=2.1.0=pyhd8ed1ab_1
-  - expat=2.6.4=h5888daf_0
+  - executing=2.2.0=pyhd8ed1ab_0
+  - expat=2.7.0=h5888daf_0
   - fasteners=0.19=pyhd8ed1ab_1
   - fbpca=1.0=pyhd8ed1ab_1
   - firefly-client=3.3.0=pyhd8ed1ab_1
@@ -124,34 +127,33 @@ dependencies:
   - fontconfig=2.15.0=h7e30c49_1
   - fonts-conda-ecosystem=1=0
   - fonts-conda-forge=1=0
-  - fonttools=4.56.0=py312h178313f_0
+  - fonttools=4.57.0=py312h178313f_0
   - fqdn=1.5.1=pyhd8ed1ab_1
-  - freetype=2.13.3=h48d6fc4_0
+  - freetype=2.13.3=ha770c72_1
   - freexl=2.0.0=h9dce30a_2
   - frozenlist=1.5.0=py312h178313f_1
-  - fsspec=2025.3.0=pyhd8ed1ab_0
+  - fsspec=2025.3.2=pyhd8ed1ab_0
   - future=1.0.0=pyhd8ed1ab_2
   - gast=0.4.0=pyh9f0ad1d_0
   - geos=3.13.1=h97f6797_0
-  - geotiff=1.7.4=h3551947_0
+  - geotiff=1.7.4=h239500f_2
   - gflags=2.2.2=h5888daf_1005
   - giflib=5.2.2=hd590300_0
   - glog=0.7.1=hbabe93e_0
   - gmp=6.3.0=hac33072_2
   - graphite2=1.3.13=h59595ed_1003
-  - greenlet=3.1.1=py312h2ec8cdc_1
+  - greenlet=3.2.1=py312h2ec8cdc_0
   - gwcs=0.24.0=pyhd8ed1ab_0
-  - h11=0.14.0=pyhd8ed1ab_1
+  - h11=0.16.0=pyhd8ed1ab_0
   - h2=4.2.0=pyhd8ed1ab_0
-  - h5py=3.13.0=nompi_py312hedeef09_100
-  - harfbuzz=10.4.0=h76408a6_0
-  - hdf5=1.14.3=nompi_h2d575fe_109
-  - healpy=1.18.0=py312h703ab46_2
-  - hipscat=0.3.5=pyhd8ed1ab_0
+  - h5py=3.13.0=nompi_py312h01d377b_101
+  - harfbuzz=11.1.0=h3beb420_0
+  - hats=0.5.1=pyhd8ed1ab_0
+  - hdf5=1.14.6=nompi_h2d575fe_101
   - hpack=4.1.0=pyhd8ed1ab_0
   - hpgeom=1.4.0=py312hc0a28a1_0
   - html5lib=1.1=pyhd8ed1ab_2
-  - httpcore=1.0.7=pyh29332c3_1
+  - httpcore=1.0.9=pyh29332c3_0
   - httpx=0.28.1=pyhd8ed1ab_0
   - hyperframe=6.1.0=pyhd8ed1ab_0
   - icu=75.1=he02047a_0
@@ -163,11 +165,11 @@ dependencies:
   - iniconfig=2.0.0=pyhd8ed1ab_1
   - ipydatagrid=1.4.0=pyhd8ed1ab_1
   - ipykernel=6.29.5=pyh3099207_0
-  - ipython=9.0.2=pyhfb0248b_0
+  - ipython=9.2.0=pyhfb0248b_0
   - ipython_pygments_lexers=1.1.1=pyhd8ed1ab_0
   - ipyvue=1.11.2=pyhd8ed1ab_0
   - ipyvuetify=1.11.0=pyhd8ed1ab_0
-  - ipywidgets=8.1.5=pyhd8ed1ab_1
+  - ipywidgets=8.1.7=pyhd8ed1ab_0
   - isoduration=20.11.0=pyhd8ed1ab_1
   - jaraco.classes=3.4.0=pyhd8ed1ab_2
   - jaraco.context=6.0.1=pyhd8ed1ab_0
@@ -176,17 +178,17 @@ dependencies:
   - jeepney=0.9.0=pyhd8ed1ab_0
   - jinja2=3.1.6=pyhd8ed1ab_0
   - jmespath=1.0.1=pyhd8ed1ab_1
-  - joblib=1.4.2=pyhd8ed1ab_1
+  - joblib=1.5.0=pyhd8ed1ab_0
   - jplephem=2.21=pyh9b8db34_1
+  - jproperties=2.1.2=pyhd8ed1ab_1
   - json-c=0.18=h6688a6e_0
-  - json5=0.10.0=pyhd8ed1ab_1
+  - json5=0.12.0=pyhd8ed1ab_0
   - jsonpointer=3.0.0=py312h7900ff3_1
   - jsonschema=4.23.0=pyhd8ed1ab_1
-  - jsonschema-specifications=2024.10.1=pyhd8ed1ab_1
+  - jsonschema-specifications=2025.4.1=pyh29332c3_0
   - jsonschema-with-format-nongpl=4.23.0=hd8ed1ab_1
   - jupyter-lsp=2.2.5=pyhd8ed1ab_1
   - jupyter-server-proxy=4.4.0=pyhd8ed1ab_1
-  - jupyter-vscode-proxy=0.6=pyhd8ed1ab_1
   - jupyter_client=8.6.3=pyhd8ed1ab_1
   - jupyter_core=5.7.2=pyh31011fe_1
   - jupyter_events=0.12.0=pyh29332c3_0
@@ -197,8 +199,8 @@ dependencies:
   - jupyterlab=4.3.6=pyhd8ed1ab_0
   - jupyterlab_pygments=0.3.0=pyhd8ed1ab_2
   - jupyterlab_server=2.27.3=pyhd8ed1ab_1
-  - jupyterlab_widgets=3.0.13=pyhd8ed1ab_1
-  - jupytext=1.16.7=pyhbbac1ac_0
+  - jupyterlab_widgets=3.0.15=pyhd8ed1ab_0
+  - jupytext=1.17.1=pyh80e38bb_0
   - jxrlib=1.1=hd590300_3
   - keyring=25.6.0=pyha804496_0
   - keyutils=1.6.1=h166bdaf_0
@@ -208,16 +210,16 @@ dependencies:
   - lazy_loader=0.4=pyhd8ed1ab_2
   - lcms2=2.17=h717163a_0
   - ld_impl_linux-64=2.43=h712a8e2_4
-  - lerc=4.0.0=h27087fc_0
+  - lerc=4.0.0=h0aef613_1
   - libabseil=20250127.1=cxx17_hbbce691_0
   - libaec=1.1.3=h59595ed_0
   - libamd=3.3.3=haaf9dc3_7100102
-  - libarchive=3.7.7=h4585015_3
-  - libarrow=19.0.1=h120c447_5_cpu
-  - libarrow-acero=19.0.1=hcb10f89_5_cpu
-  - libarrow-dataset=19.0.1=hcb10f89_5_cpu
-  - libarrow-substrait=19.0.1=h1bed206_5_cpu
-  - libavif16=1.2.1=h63b8bd6_0
+  - libarchive=3.7.7=h75ea233_4
+  - libarrow=20.0.0=h27f8bab_0_cpu
+  - libarrow-acero=20.0.0=hcb10f89_0_cpu
+  - libarrow-dataset=20.0.0=hcb10f89_0_cpu
+  - libarrow-substrait=20.0.0=h1bed206_0_cpu
+  - libavif16=1.2.1=hbb36593_2
   - libblas=3.9.0=31_h59b9bed_openblas
   - libbrotlicommon=1.1.0=hb9d3cd8_2
   - libbrotlidec=1.1.0=hb9d3cd8_2
@@ -227,80 +229,76 @@ dependencies:
   - libcblas=3.9.0=31_he106b2a_openblas
   - libccolamd=3.3.4=h32481e8_7100102
   - libcholmod=5.3.1=h59ddab4_7100102
-  - libclang-cpp19.1=19.1.7=default_hb5137d0_2
-  - libclang13=19.1.7=default_h9c6a7e4_2
+  - libclang-cpp20.1=20.1.4=default_h1df26ce_0
+  - libclang13=20.1.4=default_he06ed0a_0
   - libcolamd=3.3.4=h32481e8_7100102
   - libcrc32c=1.1.2=h9c3ff4c_0
   - libcups=2.3.3=h4637d8d_4
-  - libcurl=8.12.1=h332b0f4_0
+  - libcurl=8.13.0=h332b0f4_0
   - libcxsparse=4.4.1=h32481e8_7100102
-  - libde265=1.0.15=h00ab1b0_0
-  - libdeflate=1.23=h4ddbbb0_0
+  - libdeflate=1.23=h86f0d12_0
   - libdrm=2.4.124=hb9d3cd8_0
   - libedit=3.1.20250104=pl5321h7949ede_0
   - libegl=1.7.0=ha4b6fd6_2
   - libev=4.33=hd590300_2
   - libevent=2.1.12=hf998b51_1
-  - libexpat=2.6.4=h5888daf_0
-  - libffi=3.4.6=h2dba641_0
+  - libexpat=2.7.0=h5888daf_0
+  - libffi=3.4.6=h2dba641_1
+  - libfreetype=2.13.3=ha770c72_1
+  - libfreetype6=2.13.3=h48d6fc4_1
   - libgcc=14.2.0=h767d61c_2
   - libgcc-ng=14.2.0=h69a702a_2
-  - libgcrypt-lib=1.11.0=hb9d3cd8_2
-  - libgdal-core=3.10.2=h05269f4_1
+  - libgdal-core=3.10.3=hab2de9c_5
   - libgfortran=14.2.0=h69a702a_2
   - libgfortran-ng=14.2.0=h69a702a_2
   - libgfortran5=14.2.0=hf1ad2bd_2
   - libgl=1.7.0=ha4b6fd6_2
-  - libglib=2.82.2=h2ff4ddf_1
+  - libglib=2.84.1=h2ff4ddf_0
   - libglvnd=1.7.0=ha4b6fd6_2
   - libglx=1.7.0=ha4b6fd6_2
   - libgomp=14.2.0=h767d61c_2
   - libgoogle-cloud=2.36.0=hc4361e1_1
   - libgoogle-cloud-storage=2.36.0=h0121fbd_1
-  - libgpg-error=1.51=hbd13f7d_1
-  - libgrpc=1.71.0=he753a82_0
-  - libheif=1.19.7=gpl_hc18d805_100
+  - libgrpc=1.71.0=h8e591d7_1
   - libhwloc=2.11.2=default_h0d58e46_1001
-  - libhwy=1.1.0=h00ab1b0_0
+  - libhwy=1.2.0=hf40a0c7_0
   - libiconv=1.18=h4ce23a2_1
-  - libjpeg-turbo=3.0.0=hd590300_1
-  - libjxl=0.11.1=hdb8da77_0
+  - libjpeg-turbo=3.1.0=hb9d3cd8_0
+  - libjxl=0.11.1=h7b0646d_1
   - libklu=2.3.5=hf24d653_7100102
   - libkml=1.3.0=hf539b9f_1021
   - liblapack=3.9.0=31_h7ac8fdf_openblas
   - libldl=3.3.2=h32481e8_7100102
-  - libllvm15=15.0.7=ha7bfdaf_5
-  - libllvm19=19.1.7=ha7bfdaf_1
-  - liblzma=5.6.4=hb9d3cd8_0
-  - liblzma-devel=5.6.4=hb9d3cd8_0
+  - libllvm20=20.1.4=he9d0ab4_0
+  - liblzma=5.8.1=hb9d3cd8_0
+  - liblzma-devel=5.8.1=hb9d3cd8_0
   - libnghttp2=1.64.0=h161d5f1_0
   - libnsl=2.0.1=hd590300_0
   - libntlm=1.8=hb9d3cd8_0
   - libopenblas=0.3.29=pthreads_h94d23a6_0
   - libopengl=1.7.0=ha4b6fd6_2
-  - libopentelemetry-cpp=1.19.0=hd1b1c89_0
-  - libopentelemetry-cpp-headers=1.19.0=ha770c72_0
-  - libparquet=19.0.1=h081d1f1_5_cpu
+  - libopentelemetry-cpp=1.20.0=hd1b1c89_0
+  - libopentelemetry-cpp-headers=1.20.0=ha770c72_0
+  - libparquet=20.0.0=h081d1f1_0_cpu
   - libparu=1.0.0=h17147ab_7100102
   - libpciaccess=0.18=hd590300_0
   - libpng=1.6.47=h943b412_0
-  - libpq=17.4=h27ae623_0
-  - libprotobuf=5.29.3=h501fc15_0
+  - libpq=17.4=h27ae623_1
+  - libprotobuf=5.29.3=h501fc15_1
   - librbio=4.3.4=h32481e8_7100102
   - libre2-11=2024.07.02=hba17884_3
   - librttopo=1.1.0=hd718a1a_18
-  - libsecret=0.21.7=h1e2da66_0
   - libsodium=1.0.20=h4ab18f5_0
-  - libspatialite=5.1.0=h366e088_13
+  - libspatialite=5.1.0=he17ca71_14
   - libspex=3.2.3=had10066_7100102
   - libspqr=4.3.4=h852d39f_7100102
   - libsqlite=3.49.1=hee588c1_2
-  - libssh2=1.11.1=hf672d98_0
+  - libssh2=1.11.1=hcf80075_0
   - libstdcxx=14.2.0=h8f9b012_2
   - libstdcxx-ng=14.2.0=h4852527_2
   - libsuitesparseconfig=7.10.1=h92d6892_7100102
   - libthrift=0.21.0=h0e7cc3e_0
-  - libtiff=4.7.0=hd9ff511_3
+  - libtiff=4.7.0=hd9ff511_4
   - libumfpack=6.3.5=heb53515_7100102
   - libutf8proc=2.10.0=h4c51ac1_0
   - libuuid=2.38.1=h0b41bf4_0
@@ -308,20 +306,20 @@ dependencies:
   - libwebp-base=1.5.0=h851e524_0
   - libxcb=1.17.0=h8a09558_0
   - libxcrypt=4.4.36=hd590300_1
-  - libxkbcommon=1.8.1=hc4a0caf_0
-  - libxml2=2.13.6=h8d12d68_0
+  - libxkbcommon=1.9.1=h65c71a3_0
+  - libxml2=2.13.7=h4bc477f_1
   - libxslt=1.1.39=h76b75d6_0
   - libzlib=1.3.1=hb9d3cd8_2
   - libzopfli=1.0.3=h9c3ff4c_0
   - lightkurve=2.5.0=pyhd8ed1ab_1
-  - llvmlite=0.44.0=py312h374181b_0
+  - llvmlite=0.44.0=py312h374181b_1
   - locket=1.0.0=pyhd8ed1ab_0
-  - lsdb=0.2.6=pyhd8ed1ab_0
+  - lsdb=0.4.6=pyhd8ed1ab_0
   - lsst-sphgeom=28.2025.200=py312hf9745cd_0
   - lz4=4.3.3=py312hf0f0c11_2
   - lz4-c=1.10.0=h5888daf_1
   - lzo=2.10=hd590300_1001
-  - mako=1.3.9=pyhd8ed1ab_0
+  - mako=1.3.10=pyhd8ed1ab_0
   - markdown-it-py=3.0.0=pyhd8ed1ab_1
   - markupsafe=3.0.2=py312h178313f_1
   - matplotlib=3.10.1=py312h7900ff3_0
@@ -331,20 +329,20 @@ dependencies:
   - mdurl=0.1.2=pyhd8ed1ab_1
   - memoization=0.4.0=pyhd8ed1ab_2
   - metis=5.1.0=hd0bcaf9_1007
-  - minizip=4.0.7=h05a5f5f_3
+  - minizip=4.0.10=h05a5f5f_0
   - mistune=3.1.3=pyh29332c3_0
   - mocpy=0.17.1=py312h12e396e_1
-  - more-itertools=10.6.0=pyhd8ed1ab_0
+  - more-itertools=10.7.0=pyhd8ed1ab_0
   - mpfr=4.2.1=h90cbb55_3
   - mpl_animators=1.2.0=pyhd8ed1ab_2
   - mpld3=0.5.10=pyhd8ed1ab_1
   - mpmath=1.3.0=pyhd8ed1ab_1
   - msgpack-python=1.1.0=py312h68727a3_0
-  - multidict=6.2.0=py312h178313f_0
+  - multidict=6.4.3=py312h178313f_0
   - munkres=1.1.4=pyh9f0ad1d_0
-  - mysql-common=9.0.1=h266115a_5
-  - mysql-libs=9.0.1=he0572af_5
-  - narwhals=1.31.0=pyhd8ed1ab_0
+  - mysql-common=9.2.0=h266115a_0
+  - mysql-libs=9.2.0=he0572af_0
+  - narwhals=1.38.0=pyhe01879c_0
   - nbclient=0.10.2=pyhd8ed1ab_0
   - nbconvert-core=7.16.6=pyh29332c3_0
   - nbformat=5.10.4=pyhd8ed1ab_1
@@ -352,81 +350,82 @@ dependencies:
   - ncurses=6.5=h2d0b736_3
   - ndcube=2.3.1=pyhd8ed1ab_0
   - nest-asyncio=1.6.0=pyhd8ed1ab_1
-  - netpbm=10.86.44=pl5321h243e911_0
+  - nested-dask=0.3.4=pyhd8ed1ab_1
+  - nested-pandas=0.3.9=pyhd8ed1ab_0
+  - netpbm=10.86.46=pl5321h9c24750_0
   - networkx=3.4.2=pyh267e887_2
-  - nlohmann_json=3.11.3=he02047a_1
-  - nodejs=18.20.5=h6f0827f_0
+  - nlohmann_json=3.12.0=h3f2d84a_0
+  - nodejs=20.18.1=hc55a1b2_0
   - notebook=7.3.3=pyhd8ed1ab_0
   - notebook-shim=0.2.4=pyhd8ed1ab_1
-  - numba=0.61.0=py312h2e6246c_1
+  - numba=0.61.2=py312h2e6246c_0
   - numcodecs=0.15.1=py312hf9745cd_0
   - numpy=1.26.4=py312heda63a1_0
   - oauthlib=3.2.2=pyhd8ed1ab_1
   - oktopus=0.1.2=pyhecae5ae_1
   - openjpeg=2.5.3=h5fbd93e_0
   - openldap=2.6.9=he970967_0
-  - openssl=3.4.1=h7b32b05_0
-  - openvscode-server=1.96.0=h346b9c0_1
+  - openssl=3.5.0=h7b32b05_1
   - orc=2.1.1=h17f744e_1
   - overrides=7.7.0=pyhd8ed1ab_1
-  - packaging=24.2=pyhd8ed1ab_2
+  - packaging=25.0=pyh29332c3_1
   - pamela=1.2.0=pyhd8ed1ab_1
-  - pandas=2.2.3=py312hf9745cd_1
+  - pandas=2.2.3=py312hf9745cd_3
   - pandocfilters=1.5.0=pyhd8ed1ab_0
   - parso=0.8.4=pyhd8ed1ab_1
   - partd=1.4.2=pyhd8ed1ab_0
   - patsy=1.0.1=pyhd8ed1ab_1
-  - pcre2=10.44=hba22ea6_2
+  - pcre2=10.44=hc749103_2
   - perl=5.32.1=7_hd590300_perl5
   - pexpect=4.9.0=pyhd8ed1ab_1
   - pgplot=5.2.2=hbeaba86_1009
   - photutils=2.2.0=py312hc0a28a1_0
   - pickleshare=0.7.5=pyhd8ed1ab_1004
   - pillow=11.1.0=py312h80c1187_0
-  - pip=25.0.1=pyh8b19718_0
-  - pixman=0.44.2=h29eaf8c_0
+  - pip=25.1.1=pyh8b19718_0
+  - pixman=0.46.0=h29eaf8c_0
   - pkg-config=0.29.2=h4bc722e_1009
   - pkgutil-resolve-name=1.3.10=pyhd8ed1ab_2
-  - platformdirs=4.3.6=pyhd8ed1ab_1
+  - platformdirs=4.3.7=pyh29332c3_0
   - pluggy=1.5.0=pyhd8ed1ab_1
-  - proj=9.5.1=h0054346_0
+  - proj=9.6.0=h0054346_1
   - prometheus-cpp=1.3.0=ha5d0236_0
   - prometheus_client=0.21.1=pyhd8ed1ab_0
-  - prompt-toolkit=3.0.50=pyha770c72_0
-  - propcache=0.2.1=py312h178313f_1
+  - prompt-toolkit=3.0.51=pyha770c72_0
+  - propcache=0.3.1=py312h178313f_0
   - psutil=7.0.0=py312h66e93f0_0
   - pthread-stubs=0.4=hb9d3cd8_1002
   - ptyprocess=0.7.0=pyhd8ed1ab_1
   - pure_eval=0.2.3=pyhd8ed1ab_1
   - py2vega=0.6.1=pyhd8ed1ab_0
-  - pyarrow=19.0.1=py312h7900ff3_0
-  - pyarrow-core=19.0.1=py312h01725c0_0_cpu
+  - pyarrow=20.0.0=py312h7900ff3_0
+  - pyarrow-core=20.0.0=py312h01725c0_0_cpu
   - pycparser=2.22=pyh29332c3_1
   - pycurl=7.45.6=py312h6ac1089_0
-  - pydantic=2.10.6=pyh3cfb1c2_0
-  - pydantic-core=2.27.2=py312h12e396e_0
+  - pydantic=2.11.3=pyh3cfb1c2_0
+  - pydantic-core=2.33.1=py312h3b7be25_0
   - pyerfa=2.0.1.5=py312hc0a28a1_0
   - pygments=2.19.1=pyhd8ed1ab_0
   - pyjwt=2.10.1=pyhd8ed1ab_0
   - pynndescent=0.5.13=pyhd8ed1ab_1
-  - pyparsing=3.2.1=pyhd8ed1ab_0
-  - pyside6=6.8.2=py312h91f0f75_1
+  - pyparsing=3.2.3=pyhd8ed1ab_1
+  - pyside6=6.9.0=py312h91f0f75_0
   - pysocks=1.7.1=pyha55dd90_7
   - pytest=8.3.5=pyhd8ed1ab_0
   - python=3.12.0=hab00c5b_0_cpython
   - python-dateutil=2.9.0.post0=pyhff2d567_1
   - python-fastjsonschema=2.21.1=pyhd8ed1ab_0
   - python-json-logger=2.0.7=pyhd8ed1ab_0
-  - python-tzdata=2025.1=pyhd8ed1ab_0
-  - python_abi=3.12=5_cp312
-  - pytz=2024.1=pyhd8ed1ab_0
-  - pyvo=1.6.1=pyhd8ed1ab_0
+  - python-tzdata=2025.2=pyhd8ed1ab_0
+  - python_abi=3.12=7_cp312
+  - pytz=2025.2=pyhd8ed1ab_0
+  - pyvo=1.6.2=pyhd8ed1ab_0
   - pywavelets=1.8.0=py312hc0a28a1_0
   - pyyaml=6.0.2=py312h178313f_2
-  - pyzmq=26.3.0=py312hbf22597_0
+  - pyzmq=26.4.0=py312hbf22597_0
   - qhull=2020.2=h434a139_5
-  - qt6-main=6.8.2=h588cce1_0
-  - rasterio=1.4.3=py312h8cae83d_0
+  - qt6-main=6.9.0=h6441bc3_1
+  - rasterio=1.4.3=py312h021bea1_1
   - rav1e=0.6.6=he8a937b_2
   - re2=2024.07.02=h9925aae_3
   - readline=8.2=h8c095d6_2
@@ -436,10 +435,9 @@ dependencies:
   - requests=2.32.3=pyhd8ed1ab_1
   - rfc3339-validator=0.1.4=pyhd8ed1ab_1
   - rfc3986-validator=0.1.1=pyh9f0ad1d_0
-  - ripgrep=14.1.1=h8fae777_0
-  - rpds-py=0.23.1=py312h3b7be25_0
-  - s2n=1.5.14=h6c98b2b_0
-  - s3fs=2025.3.0=pyhd8ed1ab_0
+  - rpds-py=0.24.0=py312h3b7be25_0
+  - s2n=1.5.17=hba75a32_0
+  - s3fs=2025.3.2=pyhd8ed1ab_0
   - s3transfer=0.11.3=pyhd8ed1ab_0
   - scikit-image=0.25.2=py312hf9745cd_0
   - scikit-learn=1.6.1=py312h7a48858_0
@@ -449,8 +447,8 @@ dependencies:
   - secretstorage=3.3.3=py312h7900ff3_3
   - semantic_version=2.10.0=pyhd8ed1ab_0
   - send2trash=1.8.3=pyh0d859eb_1
-  - setuptools=75.8.2=pyhff2d567_0
-  - shapely=2.0.7=py312h21f5128_1
+  - setuptools=80.1.0=pyhff2d567_0
+  - shapely=2.1.0=py312h21f5128_0
   - simpervisor=1.0.0=pyhd8ed1ab_1
   - six=1.17.0=pyhd8ed1ab_0
   - snappy=1.2.1=h8bd8927_1
@@ -458,19 +456,19 @@ dependencies:
   - snuggs=1.4.7=pyhd8ed1ab_2
   - sortedcontainers=2.4.0=pyhd8ed1ab_1
   - soupsieve=2.5=pyhd8ed1ab_1
-  - specutils=1.19.0=pyhd8ed1ab_2
-  - sqlalchemy=2.0.39=py312h66e93f0_1
+  - specutils=1.20.0=pyhd8ed1ab_0
+  - sqlalchemy=2.0.40=py312h66e93f0_0
   - sqlite=3.49.1=h9eae976_2
   - stack_data=0.6.3=pyhd8ed1ab_1
   - statsmodels=0.14.4=py312hc0a28a1_0
   - suitesparse=7.10.1=ha0f6916_7100102
-  - svt-av1=3.0.1=h5888daf_0
-  - swig=4.3.0=heed6a68_0
-  - tbb=2022.0.0=hceb3a55_0
-  - tblib=3.0.0=pyhd8ed1ab_1
+  - svt-av1=3.0.2=h5888daf_0
+  - swig=4.3.1=heed6a68_0
+  - tbb=2022.1.0=h4ce085d_0
+  - tblib=3.1.0=pyhd8ed1ab_0
   - terminado=0.18.1=pyh0d859eb_0
   - threadpoolctl=3.6.0=pyhecae5ae_0
-  - tifffile=2025.3.13=pyhd8ed1ab_0
+  - tifffile=2025.3.30=pyhd8ed1ab_0
   - tinycss2=1.4.0=pyhd8ed1ab_0
   - tk=8.6.13=noxft_h4845f30_101
   - tomli=2.2.1=pyhd8ed1ab_1
@@ -480,26 +478,27 @@ dependencies:
   - traitlets=5.14.3=pyhd8ed1ab_1
   - traittypes=0.2.1=pyh9f0ad1d_2
   - types-python-dateutil=2.9.0.20241206=pyhd8ed1ab_0
-  - typing-extensions=4.12.2=hd8ed1ab_1
-  - typing_extensions=4.12.2=pyha770c72_1
+  - typing-extensions=4.13.2=h0e9735f_0
+  - typing-inspection=0.4.0=pyhd8ed1ab_0
+  - typing_extensions=4.13.2=pyh29332c3_0
   - typing_utils=0.1.0=pyhd8ed1ab_1
-  - tzdata=2025a=h78e105d_0
+  - tzdata=2025b=h78e105d_0
   - umap-learn=0.5.7=py312h7900ff3_1
-  - uncertainties=3.2.2=pyhd8ed1ab_2
+  - uncertainties=3.2.3=pyhd8ed1ab_0
   - unicodedata2=16.0.0=py312h66e93f0_0
+  - universal_pathlib=0.2.6=pyhd8ed1ab_1
   - uri-template=1.3.0=pyhd8ed1ab_1
   - uriparser=0.9.8=hac33072_0
-  - urllib3=2.3.0=pyhd8ed1ab_0
-  - wayland=1.23.1=h3e06ad9_0
-  - wcslib=8.2.2=h60ba7f6_3
+  - urllib3=2.4.0=pyhd8ed1ab_0
+  - wayland=1.23.1=h3e06ad9_1
+  - wcslib=8.2.2=hb2950f3_5
   - wcwidth=0.2.13=pyhd8ed1ab_1
   - webcolors=24.11.1=pyhd8ed1ab_0
   - webencodings=0.5.1=pyhd8ed1ab_3
   - websocket-client=1.8.0=pyhd8ed1ab_1
   - wheel=0.45.1=pyhd8ed1ab_1
-  - widgetsnbextension=4.0.13=pyhd8ed1ab_1
+  - widgetsnbextension=4.0.14=pyhd8ed1ab_0
   - wrapt=1.17.2=py312h66e93f0_0
-  - x265=3.5=h924138e_3
   - xcb-util=0.4.1=hb711507_2
   - xcb-util-cursor=0.1.5=hb9d3cd8_0
   - xcb-util-image=0.4.0=hb711507_2
@@ -507,7 +506,7 @@ dependencies:
   - xcb-util-renderutil=0.3.10=hb711507_0
   - xcb-util-wm=0.4.2=hb711507_0
   - xerces-c=3.2.5=h988505b_2
-  - xkeyboard-config=2.43=hb9d3cd8_0
+  - xkeyboard-config=2.44=hb9d3cd8_0
   - xorg-libice=1.1.2=hb9d3cd8_0
   - xorg-libsm=1.2.6=he73a12e_0
   - xorg-libx11=1.8.12=h4f16b4b_0
@@ -523,31 +522,32 @@ dependencies:
   - xorg-libxrender=0.9.12=hb9d3cd8_0
   - xorg-libxtst=1.2.5=hb9d3cd8_3
   - xorg-libxxf86vm=1.1.6=hb9d3cd8_0
-  - xyzservices=2025.1.0=pyhd8ed1ab_0
-  - xz=5.6.4=hbcc6ac9_0
-  - xz-gpl-tools=5.6.4=hbcc6ac9_0
-  - xz-tools=5.6.4=hb9d3cd8_0
+  - xyzservices=2025.4.0=pyhd8ed1ab_0
+  - xz=5.8.1=hbcc6ac9_0
+  - xz-gpl-tools=5.8.1=hbcc6ac9_0
+  - xz-tools=5.8.1=hb9d3cd8_0
   - yaml=0.2.5=h7f98852_2
-  - yarl=1.18.3=py312h178313f_1
-  - zarr=2.18.4=pyhd8ed1ab_0
+  - yarl=1.20.0=py312h178313f_0
+  - zarr=2.18.7=pyhd8ed1ab_0
   - zeromq=4.3.5=h3b0a872_7
   - zfp=1.0.1=h5888daf_2
   - zict=3.0.0=pyhd8ed1ab_1
   - zipp=3.21.0=pyhd8ed1ab_1
   - zlib=1.3.1=hb9d3cd8_2
   - zlib-ng=2.2.4=h7955e40_0
-  - zstandard=0.23.0=py312h66e93f0_1
-  - zstd=1.5.7=hb8e6e7a_1
+  - zstandard=0.23.0=py312h66e93f0_2
+  - zstd=1.5.7=hb8e6e7a_2
   - pip:
     - alerce==1.4.0
     - gdown==5.2.0
-    - ipyaladin==0.5.2
-    - jdaviz==4.2.0
+    - ipyaladin==0.6.0
+    - jdaviz==4.2.1
     - jupyter-resource-usage==1.1.1
     - jupyter_cpu_alive==0.1.2
     - jupyter_firefly_extensions==4.4.0
+    - jupyter_vscode_proxy==0.6
     - jupyterlab_execute_time==3.2.0
-    - jupyterlab_git==0.51.0
+    - jupyterlab_git==0.51.1
     - jupyterlab_myst==2.4.2
     - specreduce==1.4.1
 

--- a/astro-default/introduction.md
+++ b/astro-default/introduction.md
@@ -24,7 +24,11 @@ at the start of every new session. To disable these updates, add an empty file c
 ---
 # Latest Changes
 
-## 20/03/2025
+## 05/04/2025
+- Fix openvscode-server by using jupyter-openvscodeserver-proxy instead of jupyter-vscode-proxy.
+- Update packages to the latest possible.
+
+## 03/20/2025
 - Add jdaviz (and dependencies) to support JWST notebooks.
 - Update python to 3.12 (and iupyterlab==4.3.6, jupyterhub==5.2.1, notebook==7.3.3).
 - Update various other packages to the latest.

--- a/base-image/Dockerfile
+++ b/base-image/Dockerfile
@@ -95,8 +95,9 @@ RUN cat $HOME/.bashrc >> /etc/bash.bashrc \
  && printf "" > $HOME/.bashrc
 USER $NB_USER
 
-# For vscode
-ENV CODE_EXECUTABLE=openvscode-server
+# For vscode; install code-server or openvscode-server
+# extenseion added by jupyter-vscode-proxy
+ENV CODE_EXECUTABLE=code-server
 
 # For outside mount when using outside fornax
 RUN mkdir -p /opt/workspace

--- a/base-image/conda-notebook-lock.yml
+++ b/base-image/conda-notebook-lock.yml
@@ -6,11 +6,11 @@ dependencies:
   - _openmp_mutex=4.5=2_gnu
   - aiobotocore=2.21.1=pyhd8ed1ab_0
   - aiohappyeyeballs=2.6.1=pyhd8ed1ab_0
-  - aiohttp=3.11.14=py312h178313f_0
+  - aiohttp=3.11.18=py312h178313f_0
   - aioitertools=0.12.0=pyhd8ed1ab_1
   - aiosignal=1.3.2=pyhd8ed1ab_0
-  - alembic=1.15.1=pyhd8ed1ab_0
-  - alsa-lib=1.2.13=hb9d3cd8_0
+  - alembic=1.15.2=pyhd8ed1ab_0
+  - alsa-lib=1.2.14=hb9d3cd8_0
   - annotated-types=0.7.0=pyhd8ed1ab_1
   - anyio=4.9.0=pyh29332c3_0
   - argon2-cffi=23.1.0=pyhd8ed1ab_1
@@ -18,25 +18,25 @@ dependencies:
   - arrow=1.3.0=pyhd8ed1ab_1
   - astropy=7.0.1=pyhd8ed1ab_0
   - astropy-base=7.0.1=py312hb8e8fe3_0
-  - astropy-iers-data=0.2025.3.17.0.34.53=pyhd8ed1ab_0
+  - astropy-iers-data=0.2025.5.5.0.38.14=pyhd8ed1ab_0
   - astroquery=0.4.10=pyhd8ed1ab_0
   - asttokens=3.0.0=pyhd8ed1ab_1
   - async-lru=2.0.5=pyh29332c3_0
   - async_generator=1.10=pyhd8ed1ab_2
   - attrs=25.3.0=pyh71513ae_0
-  - aws-c-auth=0.8.6=hd08a7f5_4
-  - aws-c-cal=0.8.7=h043a21b_0
-  - aws-c-common=0.12.0=hb9d3cd8_0
-  - aws-c-compression=0.3.1=h3870646_2
-  - aws-c-event-stream=0.5.4=h04a3f94_2
-  - aws-c-http=0.9.4=hb9b18c6_4
-  - aws-c-io=0.17.0=h3dad3f2_6
-  - aws-c-mqtt=0.12.2=h108da3e_2
-  - aws-c-s3=0.7.13=h822ba82_2
-  - aws-c-sdkutils=0.2.3=h3870646_2
-  - aws-checksums=0.2.3=h3870646_2
-  - aws-crt-cpp=0.31.0=h55f77e1_4
-  - aws-sdk-cpp=1.11.510=h37a5c72_3
+  - aws-c-auth=0.9.0=h9a6e2ae_4
+  - aws-c-cal=0.9.0=hada3f3f_0
+  - aws-c-common=0.12.2=hb9d3cd8_0
+  - aws-c-compression=0.3.1=hc2d532b_4
+  - aws-c-event-stream=0.5.4=hc5e5e9e_7
+  - aws-c-http=0.10.0=h6884c39_0
+  - aws-c-io=0.18.1=h1a9f769_2
+  - aws-c-mqtt=0.12.3=hef6a231_4
+  - aws-c-s3=0.7.16=h7dfd680_1
+  - aws-c-sdkutils=0.2.3=hc2d532b_4
+  - aws-checksums=0.2.7=hc2d532b_0
+  - aws-crt-cpp=0.32.4=h0cee55f_2
+  - aws-sdk-cpp=1.11.510=h5b777a2_6
   - azure-core-cpp=1.14.0=h5cfcd09_0
   - azure-identity-cpp=1.10.0=h113e628_0
   - azure-storage-blobs-cpp=12.13.0=h3cf044e_1
@@ -45,11 +45,11 @@ dependencies:
   - babel=2.17.0=pyhd8ed1ab_0
   - backports=1.0=pyhd8ed1ab_5
   - backports.tarfile=1.2.0=pyhd8ed1ab_1
-  - beautifulsoup4=4.13.3=pyha770c72_0
+  - beautifulsoup4=4.13.4=pyha770c72_0
   - bleach=6.2.0=pyh29332c3_4
   - bleach-with-css=6.2.0=h82add2a_4
   - blinker=1.9.0=pyhff2d567_0
-  - bokeh=3.7.0=pyhd8ed1ab_0
+  - bokeh=3.7.2=pyhd8ed1ab_1
   - botocore=1.37.1=pyge310_1234567_0
   - bottleneck=1.4.2=py312hc0a28a1_0
   - bqplot=0.12.43=pyhd8ed1ab_1
@@ -57,37 +57,38 @@ dependencies:
   - brotli-bin=1.1.0=hb9d3cd8_2
   - brotli-python=1.1.0=py312h2ec8cdc_2
   - bzip2=1.0.8=h4bc722e_7
-  - c-ares=1.34.4=hb9d3cd8_0
-  - ca-certificates=2025.1.31=hbcca054_0
+  - c-ares=1.34.5=hb9d3cd8_0
+  - ca-certificates=2025.4.26=hbd8a1cb_0
   - cached-property=1.5.2=hd8ed1ab_1
   - cached_property=1.5.2=pyha770c72_1
   - cairo=1.18.4=h3394656_0
   - certifi=2025.1.31=pyhd8ed1ab_0
-  - certipy=0.2.1=pyhd8ed1ab_1
+  - certipy=0.2.2=pyhd8ed1ab_0
   - cffi=1.17.1=py312h06ac9bb_0
-  - charset-normalizer=3.4.1=pyhd8ed1ab_0
+  - charset-normalizer=3.4.2=pyhd8ed1ab_0
   - click=8.1.8=pyh707e725_0
   - cloudpickle=3.1.1=pyhd8ed1ab_0
+  - code-server=4.99.4=h59d26c6_0
   - colorama=0.4.6=pyhd8ed1ab_1
   - comm=0.2.2=pyhd8ed1ab_1
-  - configurable-http-proxy=4.6.2=he2f69ee_0
-  - contourpy=1.3.1=py312h68727a3_0
-  - cryptography=44.0.2=py312hda17c39_0
+  - configurable-http-proxy=4.6.3=h92b4e83_0
+  - contourpy=1.3.2=py312h68727a3_0
+  - cryptography=44.0.3=py312hda17c39_0
   - cycler=0.12.1=pyhd8ed1ab_1
   - cyrus-sasl=2.1.27=h54b06d7_7
   - cytoolz=1.0.1=py312h66e93f0_0
-  - dask=2025.2.0=pyhd8ed1ab_0
-  - dask-core=2025.2.0=pyhd8ed1ab_0
+  - dask=2025.4.1=pyhd8ed1ab_0
+  - dask-core=2025.4.1=pyhd8ed1ab_0
   - dask-labextension=7.0.0=pyhd8ed1ab_1
   - dbus=1.13.6=h5008d03_3
-  - debugpy=1.8.13=py312h2ec8cdc_0
+  - debugpy=1.8.14=py312h2ec8cdc_0
   - decorator=5.2.1=pyhd8ed1ab_0
   - defusedxml=0.7.1=pyhd8ed1ab_0
-  - distributed=2025.2.0=pyhd8ed1ab_0
+  - distributed=2025.4.1=pyhd8ed1ab_0
   - double-conversion=3.3.1=h5888daf_0
   - exceptiongroup=1.2.2=pyhd8ed1ab_1
-  - executing=2.1.0=pyhd8ed1ab_1
-  - expat=2.6.4=h5888daf_0
+  - executing=2.2.0=pyhd8ed1ab_0
+  - expat=2.7.0=h5888daf_0
   - font-ttf-dejavu-sans-mono=2.37=hab24e00_0
   - font-ttf-inconsolata=3.000=h77eed37_0
   - font-ttf-source-code-pro=2.038=h77eed37_0
@@ -95,24 +96,24 @@ dependencies:
   - fontconfig=2.15.0=h7e30c49_1
   - fonts-conda-ecosystem=1=0
   - fonts-conda-forge=1=0
-  - fonttools=4.56.0=py312h178313f_0
+  - fonttools=4.57.0=py312h178313f_0
   - fqdn=1.5.1=pyhd8ed1ab_1
-  - freetype=2.13.3=h48d6fc4_0
+  - freetype=2.13.3=ha770c72_1
   - frozenlist=1.5.0=py312h178313f_1
-  - fsspec=2025.3.0=pyhd8ed1ab_0
+  - fsspec=2025.3.2=pyhd8ed1ab_0
   - gast=0.4.0=pyh9f0ad1d_0
   - gflags=2.2.2=h5888daf_1005
   - glog=0.7.1=hbabe93e_0
   - graphite2=1.3.13=h59595ed_1003
-  - greenlet=3.1.1=py312h2ec8cdc_1
-  - h11=0.14.0=pyhd8ed1ab_1
+  - greenlet=3.2.1=py312h2ec8cdc_0
+  - h11=0.16.0=pyhd8ed1ab_0
   - h2=4.2.0=pyhd8ed1ab_0
-  - h5py=3.13.0=nompi_py312hedeef09_100
-  - harfbuzz=10.4.0=h76408a6_0
-  - hdf5=1.14.3=nompi_h2d575fe_109
+  - h5py=3.13.0=nompi_py312h01d377b_101
+  - harfbuzz=11.1.0=h3beb420_0
+  - hdf5=1.14.6=nompi_h2d575fe_101
   - hpack=4.1.0=pyhd8ed1ab_0
   - html5lib=1.1=pyhd8ed1ab_2
-  - httpcore=1.0.7=pyh29332c3_1
+  - httpcore=1.0.9=pyh29332c3_0
   - httpx=0.28.1=pyhd8ed1ab_0
   - hyperframe=6.1.0=pyhd8ed1ab_0
   - icu=75.1=he02047a_0
@@ -122,9 +123,9 @@ dependencies:
   - iniconfig=2.0.0=pyhd8ed1ab_1
   - ipydatagrid=1.4.0=pyhd8ed1ab_1
   - ipykernel=6.29.5=pyh3099207_0
-  - ipython=9.0.2=pyhfb0248b_0
+  - ipython=9.2.0=pyhfb0248b_0
   - ipython_pygments_lexers=1.1.1=pyhd8ed1ab_0
-  - ipywidgets=8.1.5=pyhd8ed1ab_1
+  - ipywidgets=8.1.7=pyhd8ed1ab_0
   - isoduration=20.11.0=pyhd8ed1ab_1
   - jaraco.classes=3.4.0=pyhd8ed1ab_2
   - jaraco.context=6.0.1=pyhd8ed1ab_0
@@ -134,14 +135,13 @@ dependencies:
   - jinja2=3.1.6=pyhd8ed1ab_0
   - jmespath=1.0.1=pyhd8ed1ab_1
   - jplephem=2.21=pyh9b8db34_1
-  - json5=0.10.0=pyhd8ed1ab_1
+  - json5=0.12.0=pyhd8ed1ab_0
   - jsonpointer=3.0.0=py312h7900ff3_1
   - jsonschema=4.23.0=pyhd8ed1ab_1
-  - jsonschema-specifications=2024.10.1=pyhd8ed1ab_1
+  - jsonschema-specifications=2025.4.1=pyh29332c3_0
   - jsonschema-with-format-nongpl=4.23.0=hd8ed1ab_1
   - jupyter-lsp=2.2.5=pyhd8ed1ab_1
   - jupyter-server-proxy=4.4.0=pyhd8ed1ab_1
-  - jupyter-vscode-proxy=0.6=pyhd8ed1ab_1
   - jupyter_client=8.6.3=pyhd8ed1ab_1
   - jupyter_core=5.7.2=pyh31011fe_1
   - jupyter_events=0.12.0=pyh29332c3_0
@@ -152,93 +152,92 @@ dependencies:
   - jupyterlab=4.3.6=pyhd8ed1ab_0
   - jupyterlab_pygments=0.3.0=pyhd8ed1ab_2
   - jupyterlab_server=2.27.3=pyhd8ed1ab_1
-  - jupyterlab_widgets=3.0.13=pyhd8ed1ab_1
-  - jupytext=1.16.7=pyhbbac1ac_0
+  - jupyterlab_widgets=3.0.15=pyhd8ed1ab_0
+  - jupytext=1.17.1=pyh80e38bb_0
   - keyring=25.6.0=pyha804496_0
   - keyutils=1.6.1=h166bdaf_0
   - kiwisolver=1.4.8=py312h84d6215_0
   - krb5=1.21.3=h659f571_0
   - lcms2=2.17=h717163a_0
   - ld_impl_linux-64=2.43=h712a8e2_4
-  - lerc=4.0.0=h27087fc_0
+  - lerc=4.0.0=h0aef613_1
   - libabseil=20250127.1=cxx17_hbbce691_0
   - libaec=1.1.3=h59595ed_0
-  - libarrow=19.0.1=h120c447_5_cpu
-  - libarrow-acero=19.0.1=hcb10f89_5_cpu
-  - libarrow-dataset=19.0.1=hcb10f89_5_cpu
-  - libarrow-substrait=19.0.1=h1bed206_5_cpu
+  - libarrow=20.0.0=h27f8bab_0_cpu
+  - libarrow-acero=20.0.0=hcb10f89_0_cpu
+  - libarrow-dataset=20.0.0=hcb10f89_0_cpu
+  - libarrow-substrait=20.0.0=h1bed206_0_cpu
   - libblas=3.9.0=31_h59b9bed_openblas
   - libbrotlicommon=1.1.0=hb9d3cd8_2
   - libbrotlidec=1.1.0=hb9d3cd8_2
   - libbrotlienc=1.1.0=hb9d3cd8_2
   - libcblas=3.9.0=31_he106b2a_openblas
-  - libclang-cpp19.1=19.1.7=default_hb5137d0_2
-  - libclang13=19.1.7=default_h9c6a7e4_2
+  - libclang-cpp20.1=20.1.4=default_h1df26ce_0
+  - libclang13=20.1.4=default_he06ed0a_0
   - libcrc32c=1.1.2=h9c3ff4c_0
   - libcups=2.3.3=h4637d8d_4
-  - libcurl=8.12.1=h332b0f4_0
-  - libdeflate=1.23=h4ddbbb0_0
+  - libcurl=8.13.0=h332b0f4_0
+  - libdeflate=1.23=h86f0d12_0
   - libdrm=2.4.124=hb9d3cd8_0
   - libedit=3.1.20250104=pl5321h7949ede_0
   - libegl=1.7.0=ha4b6fd6_2
   - libev=4.33=hd590300_2
   - libevent=2.1.12=hf998b51_1
-  - libexpat=2.6.4=h5888daf_0
-  - libffi=3.4.6=h2dba641_0
+  - libexpat=2.7.0=h5888daf_0
+  - libffi=3.4.6=h2dba641_1
+  - libfreetype=2.13.3=ha770c72_1
+  - libfreetype6=2.13.3=h48d6fc4_1
   - libgcc=14.2.0=h767d61c_2
   - libgcc-ng=14.2.0=h69a702a_2
-  - libgcrypt-lib=1.11.0=hb9d3cd8_2
   - libgfortran=14.2.0=h69a702a_2
   - libgfortran5=14.2.0=hf1ad2bd_2
   - libgl=1.7.0=ha4b6fd6_2
-  - libglib=2.82.2=h2ff4ddf_1
+  - libglib=2.84.1=h2ff4ddf_0
   - libglvnd=1.7.0=ha4b6fd6_2
   - libglx=1.7.0=ha4b6fd6_2
   - libgomp=14.2.0=h767d61c_2
   - libgoogle-cloud=2.36.0=hc4361e1_1
   - libgoogle-cloud-storage=2.36.0=h0121fbd_1
-  - libgpg-error=1.51=hbd13f7d_1
-  - libgrpc=1.71.0=he753a82_0
+  - libgrpc=1.71.0=h8e591d7_1
   - libiconv=1.18=h4ce23a2_1
-  - libjpeg-turbo=3.0.0=hd590300_1
+  - libjpeg-turbo=3.1.0=hb9d3cd8_0
   - liblapack=3.9.0=31_h7ac8fdf_openblas
-  - libllvm19=19.1.7=ha7bfdaf_1
-  - liblzma=5.6.4=hb9d3cd8_0
-  - liblzma-devel=5.6.4=hb9d3cd8_0
+  - libllvm20=20.1.4=he9d0ab4_0
+  - liblzma=5.8.1=hb9d3cd8_0
+  - liblzma-devel=5.8.1=hb9d3cd8_0
   - libnghttp2=1.64.0=h161d5f1_0
   - libnsl=2.0.1=hd590300_0
   - libntlm=1.8=hb9d3cd8_0
   - libopenblas=0.3.29=pthreads_h94d23a6_0
   - libopengl=1.7.0=ha4b6fd6_2
-  - libopentelemetry-cpp=1.19.0=hd1b1c89_0
-  - libopentelemetry-cpp-headers=1.19.0=ha770c72_0
-  - libparquet=19.0.1=h081d1f1_5_cpu
+  - libopentelemetry-cpp=1.20.0=hd1b1c89_0
+  - libopentelemetry-cpp-headers=1.20.0=ha770c72_0
+  - libparquet=20.0.0=h081d1f1_0_cpu
   - libpciaccess=0.18=hd590300_0
   - libpng=1.6.47=h943b412_0
-  - libpq=17.4=h27ae623_0
-  - libprotobuf=5.29.3=h501fc15_0
+  - libpq=17.4=h27ae623_1
+  - libprotobuf=5.29.3=h501fc15_1
   - libre2-11=2024.07.02=hba17884_3
-  - libsecret=0.21.7=h1e2da66_0
   - libsodium=1.0.20=h4ab18f5_0
   - libsqlite=3.49.1=hee588c1_2
-  - libssh2=1.11.1=hf672d98_0
+  - libssh2=1.11.1=hcf80075_0
   - libstdcxx=14.2.0=h8f9b012_2
   - libstdcxx-ng=14.2.0=h4852527_2
   - libthrift=0.21.0=h0e7cc3e_0
-  - libtiff=4.7.0=hd9ff511_3
+  - libtiff=4.7.0=hd9ff511_4
   - libutf8proc=2.10.0=h4c51ac1_0
   - libuuid=2.38.1=h0b41bf4_0
   - libuv=1.50.0=hb9d3cd8_0
   - libwebp-base=1.5.0=h851e524_0
   - libxcb=1.17.0=h8a09558_0
-  - libxkbcommon=1.8.1=hc4a0caf_0
-  - libxml2=2.13.6=h8d12d68_0
+  - libxkbcommon=1.9.1=h65c71a3_0
+  - libxml2=2.13.7=h4bc477f_1
   - libxslt=1.1.39=h76b75d6_0
   - libzlib=1.3.1=hb9d3cd8_2
   - locket=1.0.0=pyhd8ed1ab_0
   - lz4=4.3.3=py312hf0f0c11_2
   - lz4-c=1.10.0=h5888daf_1
-  - mako=1.3.9=pyhd8ed1ab_0
+  - mako=1.3.10=pyhd8ed1ab_0
   - markdown-it-py=3.0.0=pyhd8ed1ab_1
   - markupsafe=3.0.2=py312h178313f_1
   - matplotlib=3.10.1=py312h7900ff3_0
@@ -247,108 +246,106 @@ dependencies:
   - mdit-py-plugins=0.4.2=pyhd8ed1ab_1
   - mdurl=0.1.2=pyhd8ed1ab_1
   - mistune=3.1.3=pyh29332c3_0
-  - more-itertools=10.6.0=pyhd8ed1ab_0
+  - more-itertools=10.7.0=pyhd8ed1ab_0
   - mpmath=1.3.0=pyhd8ed1ab_1
   - msgpack-python=1.1.0=py312h68727a3_0
-  - multidict=6.2.0=py312h178313f_0
+  - multidict=6.4.3=py312h178313f_0
   - munkres=1.1.4=pyh9f0ad1d_0
-  - mysql-common=9.0.1=h266115a_5
-  - mysql-libs=9.0.1=he0572af_5
-  - narwhals=1.31.0=pyhd8ed1ab_0
+  - mysql-common=9.2.0=h266115a_0
+  - mysql-libs=9.2.0=he0572af_0
+  - narwhals=1.38.0=pyhe01879c_0
   - nbclient=0.10.2=pyhd8ed1ab_0
   - nbconvert-core=7.16.6=pyh29332c3_0
   - nbformat=5.10.4=pyhd8ed1ab_1
   - nbgitpuller=1.2.2=pyhd8ed1ab_0
   - ncurses=6.5=h2d0b736_3
   - nest-asyncio=1.6.0=pyhd8ed1ab_1
-  - nlohmann_json=3.11.3=he02047a_1
-  - nodejs=18.20.5=h6f0827f_0
+  - nlohmann_json=3.12.0=h3f2d84a_0
+  - nodejs=20.18.1=hc55a1b2_0
   - notebook=7.3.3=pyhd8ed1ab_0
   - notebook-shim=0.2.4=pyhd8ed1ab_1
   - numpy=1.26.4=py312heda63a1_0
   - oauthlib=3.2.2=pyhd8ed1ab_1
   - openjpeg=2.5.3=h5fbd93e_0
   - openldap=2.6.9=he970967_0
-  - openssl=3.4.1=h7b32b05_0
-  - openvscode-server=1.96.0=h346b9c0_1
+  - openssl=3.5.0=h7b32b05_1
   - orc=2.1.1=h17f744e_1
   - overrides=7.7.0=pyhd8ed1ab_1
-  - packaging=24.2=pyhd8ed1ab_2
+  - packaging=25.0=pyh29332c3_1
   - pamela=1.2.0=pyhd8ed1ab_1
-  - pandas=2.2.3=py312hf9745cd_1
+  - pandas=2.2.3=py312hf9745cd_3
   - pandocfilters=1.5.0=pyhd8ed1ab_0
   - parso=0.8.4=pyhd8ed1ab_1
   - partd=1.4.2=pyhd8ed1ab_0
   - patsy=1.0.1=pyhd8ed1ab_1
-  - pcre2=10.44=hba22ea6_2
+  - pcre2=10.44=hc749103_2
   - pexpect=4.9.0=pyhd8ed1ab_1
   - pickleshare=0.7.5=pyhd8ed1ab_1004
   - pillow=11.1.0=py312h80c1187_0
-  - pip=25.0.1=pyh8b19718_0
-  - pixman=0.44.2=h29eaf8c_0
+  - pip=25.1.1=pyh8b19718_0
+  - pixman=0.46.0=h29eaf8c_0
   - pkgutil-resolve-name=1.3.10=pyhd8ed1ab_2
-  - platformdirs=4.3.6=pyhd8ed1ab_1
+  - platformdirs=4.3.7=pyh29332c3_0
   - pluggy=1.5.0=pyhd8ed1ab_1
   - prometheus-cpp=1.3.0=ha5d0236_0
   - prometheus_client=0.21.1=pyhd8ed1ab_0
-  - prompt-toolkit=3.0.50=pyha770c72_0
-  - propcache=0.2.1=py312h178313f_1
+  - prompt-toolkit=3.0.51=pyha770c72_0
+  - propcache=0.3.1=py312h178313f_0
   - psutil=7.0.0=py312h66e93f0_0
   - pthread-stubs=0.4=hb9d3cd8_1002
   - ptyprocess=0.7.0=pyhd8ed1ab_1
   - pure_eval=0.2.3=pyhd8ed1ab_1
   - py2vega=0.6.1=pyhd8ed1ab_0
-  - pyarrow=19.0.1=py312h7900ff3_0
-  - pyarrow-core=19.0.1=py312h01725c0_0_cpu
+  - pyarrow=20.0.0=py312h7900ff3_0
+  - pyarrow-core=20.0.0=py312h01725c0_0_cpu
   - pycparser=2.22=pyh29332c3_1
   - pycurl=7.45.6=py312h6ac1089_0
-  - pydantic=2.10.6=pyh3cfb1c2_0
-  - pydantic-core=2.27.2=py312h12e396e_0
+  - pydantic=2.11.3=pyh3cfb1c2_0
+  - pydantic-core=2.33.1=py312h3b7be25_0
   - pyerfa=2.0.1.5=py312hc0a28a1_0
   - pygments=2.19.1=pyhd8ed1ab_0
   - pyjwt=2.10.1=pyhd8ed1ab_0
-  - pyparsing=3.2.1=pyhd8ed1ab_0
-  - pyside6=6.8.2=py312h91f0f75_1
+  - pyparsing=3.2.3=pyhd8ed1ab_1
+  - pyside6=6.9.0=py312h91f0f75_0
   - pysocks=1.7.1=pyha55dd90_7
   - pytest=8.3.5=pyhd8ed1ab_0
   - python=3.12.0=hab00c5b_0_cpython
   - python-dateutil=2.9.0.post0=pyhff2d567_1
   - python-fastjsonschema=2.21.1=pyhd8ed1ab_0
   - python-json-logger=2.0.7=pyhd8ed1ab_0
-  - python-tzdata=2025.1=pyhd8ed1ab_0
-  - python_abi=3.12=5_cp312
-  - pytz=2024.1=pyhd8ed1ab_0
-  - pyvo=1.6.1=pyhd8ed1ab_0
+  - python-tzdata=2025.2=pyhd8ed1ab_0
+  - python_abi=3.12=7_cp312
+  - pytz=2025.2=pyhd8ed1ab_0
+  - pyvo=1.6.2=pyhd8ed1ab_0
   - pyyaml=6.0.2=py312h178313f_2
-  - pyzmq=26.3.0=py312hbf22597_0
+  - pyzmq=26.4.0=py312hbf22597_0
   - qhull=2020.2=h434a139_5
-  - qt6-main=6.8.2=h588cce1_0
+  - qt6-main=6.9.0=h6441bc3_1
   - re2=2024.07.02=h9925aae_3
   - readline=8.2=h8c095d6_2
   - referencing=0.36.2=pyh29332c3_0
   - requests=2.32.3=pyhd8ed1ab_1
   - rfc3339-validator=0.1.4=pyhd8ed1ab_1
   - rfc3986-validator=0.1.1=pyh9f0ad1d_0
-  - ripgrep=14.1.1=h8fae777_0
-  - rpds-py=0.23.1=py312h3b7be25_0
-  - s2n=1.5.14=h6c98b2b_0
-  - s3fs=2025.3.0=pyhd8ed1ab_0
+  - rpds-py=0.24.0=py312h3b7be25_0
+  - s2n=1.5.17=hba75a32_0
+  - s3fs=2025.3.2=pyhd8ed1ab_0
   - scipy=1.15.2=py312ha707e6e_0
   - seaborn=0.13.2=hd8ed1ab_3
   - seaborn-base=0.13.2=pyhd8ed1ab_3
   - secretstorage=3.3.3=py312h7900ff3_3
   - send2trash=1.8.3=pyh0d859eb_1
-  - setuptools=75.8.2=pyhff2d567_0
+  - setuptools=80.1.0=pyhff2d567_0
   - simpervisor=1.0.0=pyhd8ed1ab_1
   - six=1.17.0=pyhd8ed1ab_0
   - snappy=1.2.1=h8bd8927_1
   - sniffio=1.3.1=pyhd8ed1ab_1
   - sortedcontainers=2.4.0=pyhd8ed1ab_1
   - soupsieve=2.5=pyhd8ed1ab_1
-  - sqlalchemy=2.0.39=py312h66e93f0_1
+  - sqlalchemy=2.0.40=py312h66e93f0_0
   - stack_data=0.6.3=pyhd8ed1ab_1
   - statsmodels=0.14.4=py312hc0a28a1_0
-  - tblib=3.0.0=pyhd8ed1ab_1
+  - tblib=3.1.0=pyhd8ed1ab_0
   - terminado=0.18.1=pyh0d859eb_0
   - tinycss2=1.4.0=pyhd8ed1ab_0
   - tk=8.6.13=noxft_h4845f30_101
@@ -359,20 +356,21 @@ dependencies:
   - traitlets=5.14.3=pyhd8ed1ab_1
   - traittypes=0.2.1=pyh9f0ad1d_2
   - types-python-dateutil=2.9.0.20241206=pyhd8ed1ab_0
-  - typing-extensions=4.12.2=hd8ed1ab_1
-  - typing_extensions=4.12.2=pyha770c72_1
+  - typing-extensions=4.13.2=h0e9735f_0
+  - typing-inspection=0.4.0=pyhd8ed1ab_0
+  - typing_extensions=4.13.2=pyh29332c3_0
   - typing_utils=0.1.0=pyhd8ed1ab_1
-  - tzdata=2025a=h78e105d_0
+  - tzdata=2025b=h78e105d_0
   - unicodedata2=16.0.0=py312h66e93f0_0
   - uri-template=1.3.0=pyhd8ed1ab_1
-  - urllib3=2.3.0=pyhd8ed1ab_0
-  - wayland=1.23.1=h3e06ad9_0
+  - urllib3=2.4.0=pyhd8ed1ab_0
+  - wayland=1.23.1=h3e06ad9_1
   - wcwidth=0.2.13=pyhd8ed1ab_1
   - webcolors=24.11.1=pyhd8ed1ab_0
   - webencodings=0.5.1=pyhd8ed1ab_3
   - websocket-client=1.8.0=pyhd8ed1ab_1
   - wheel=0.45.1=pyhd8ed1ab_1
-  - widgetsnbextension=4.0.13=pyhd8ed1ab_1
+  - widgetsnbextension=4.0.14=pyhd8ed1ab_0
   - wrapt=1.17.2=py312h66e93f0_0
   - xcb-util=0.4.1=hb711507_2
   - xcb-util-cursor=0.1.5=hb9d3cd8_0
@@ -380,7 +378,7 @@ dependencies:
   - xcb-util-keysyms=0.4.1=hb711507_0
   - xcb-util-renderutil=0.3.10=hb711507_0
   - xcb-util-wm=0.4.2=hb711507_0
-  - xkeyboard-config=2.43=hb9d3cd8_0
+  - xkeyboard-config=2.44=hb9d3cd8_0
   - xorg-libice=1.1.2=hb9d3cd8_0
   - xorg-libsm=1.2.6=he73a12e_0
   - xorg-libx11=1.8.12=h4f16b4b_0
@@ -396,23 +394,24 @@ dependencies:
   - xorg-libxrender=0.9.12=hb9d3cd8_0
   - xorg-libxtst=1.2.5=hb9d3cd8_3
   - xorg-libxxf86vm=1.1.6=hb9d3cd8_0
-  - xyzservices=2025.1.0=pyhd8ed1ab_0
-  - xz=5.6.4=hbcc6ac9_0
-  - xz-gpl-tools=5.6.4=hbcc6ac9_0
-  - xz-tools=5.6.4=hb9d3cd8_0
+  - xyzservices=2025.4.0=pyhd8ed1ab_0
+  - xz=5.8.1=hbcc6ac9_0
+  - xz-gpl-tools=5.8.1=hbcc6ac9_0
+  - xz-tools=5.8.1=hb9d3cd8_0
   - yaml=0.2.5=h7f98852_2
-  - yarl=1.18.3=py312h178313f_1
+  - yarl=1.20.0=py312h178313f_0
   - zeromq=4.3.5=h3b0a872_7
   - zict=3.0.0=pyhd8ed1ab_1
   - zipp=3.21.0=pyhd8ed1ab_1
   - zlib=1.3.1=hb9d3cd8_2
-  - zstandard=0.23.0=py312h66e93f0_1
-  - zstd=1.5.7=hb8e6e7a_1
+  - zstandard=0.23.0=py312h66e93f0_2
+  - zstd=1.5.7=hb8e6e7a_2
   - pip:
     - jupyter-resource-usage==1.1.1
     - jupyter_cpu_alive==0.1.2
+    - jupyter_vscode_proxy==0.6
     - jupyterlab_execute_time==3.2.0
-    - jupyterlab_git==0.51.0
+    - jupyterlab_git==0.51.1
     - jupyterlab_myst==2.4.2
 
 prefix: "/opt/conda/envs/notebook"

--- a/base-image/conda-notebook.yml
+++ b/base-image/conda-notebook.yml
@@ -21,9 +21,8 @@ dependencies:
   - tqdm
   - matplotlib
   - seaborn
-  - openvscode-server
-  - jupyter-vscode-proxy
   - pytest
+  - code-server
   - pip
   - pip:
       - jupyterlab_execute_time
@@ -31,3 +30,4 @@ dependencies:
       - jupyterlab-git
       - jupyterlab-myst
       - jupyter_cpu_alive
+      - jupyter-vscode-proxy

--- a/base-image/scripts/apt-install.sh
+++ b/base-image/scripts/apt-install.sh
@@ -4,7 +4,7 @@
 if test -f "apt.txt" ; then
     echo "Found apt.txt; using it ..."
     apt-get update --fix-missing > /dev/null
-    xargs -a apt.txt apt-get install -y
+    xargs -a apt.txt apt-get install -y -q
     apt-get clean
     apt-get -y autoremove
     rm -rf /var/lib/apt/lists/*

--- a/base-image/scripts/conda-env-install.sh
+++ b/base-image/scripts/conda-env-install.sh
@@ -12,13 +12,13 @@ for envfile in `ls conda-*.yml | grep -v lock`; do
         echo "Found $ENVFILE, using it ..."
         # create the environment if it doesn't exist
         mamba env list | grep -q "^[[:space:]]*$env " || mamba create -n ${env}
-        conda env update -n ${env} -f $ENVFILE --solver libmamba
+        conda env update -q -n ${env} -f $ENVFILE --solver libmamba
     elif test -f conda-${env}.yml; then
         ENVFILE=conda-${env}.yml
         echo "Found $ENVFILE, using it ..."
         # create the environment if it doesn't exist
         mamba env list | grep -q "^[[:space:]]*$env " || mamba create -n ${env}
-        conda env update -n ${env} -f $ENVFILE --solver libmamba
+        conda env update -q -n ${env} -f $ENVFILE --solver libmamba
     elif [[ "$env"=="$CONDA_ENV" ]]; then
         echo "Defaulting to basic env ..." 
         mamba create --name $env python=3.12 jupyterlab

--- a/heasoft/conda-heasoft-lock.yml
+++ b/heasoft/conda-heasoft-lock.yml
@@ -7,13 +7,13 @@ dependencies:
   - _openmp_mutex=4.5=2_gnu
   - alsa-lib=1.2.14=hb9d3cd8_0
   - astropy-base=7.0.1=py312hb8e8fe3_0
-  - astropy-iers-data=0.2025.4.21.0.37.6=pyhd8ed1ab_0
+  - astropy-iers-data=0.2025.5.5.0.38.14=pyhd8ed1ab_0
   - asttokens=3.0.0=pyhd8ed1ab_1
   - brotli=1.1.0=hb9d3cd8_2
   - brotli-bin=1.1.0=hb9d3cd8_2
   - bzip2=1.0.8=h4bc722e_7
   - c-ares=1.34.5=hb9d3cd8_0
-  - ca-certificates=2025.1.31=hbd8a1cb_1
+  - ca-certificates=2025.4.26=hbd8a1cb_0
   - cairo=1.18.4=h3394656_0
   - colorama=0.4.6=pyhd8ed1ab_1
   - comm=0.2.2=pyhd8ed1ab_1
@@ -25,7 +25,7 @@ dependencies:
   - decorator=5.2.1=pyhd8ed1ab_0
   - double-conversion=3.3.1=h5888daf_0
   - exceptiongroup=1.2.2=pyhd8ed1ab_1
-  - executing=2.1.0=pyhd8ed1ab_1
+  - executing=2.2.0=pyhd8ed1ab_0
   - expat=2.7.0=h5888daf_0
   - fgsl=1.6.0=hdc47aa6_0
   - font-ttf-dejavu-sans-mono=2.37=hab24e00_0
@@ -45,7 +45,7 @@ dependencies:
   - importlib-metadata=8.6.1=pyha770c72_0
   - iniconfig=2.0.0=pyhd8ed1ab_1
   - ipykernel=6.29.5=pyh3099207_0
-  - ipython=9.1.0=pyhfb0248b_0
+  - ipython=9.2.0=pyhfb0248b_0
   - ipython_pygments_lexers=1.1.1=pyhd8ed1ab_0
   - jedi=0.19.2=pyhd8ed1ab_1
   - jupyter_client=8.6.3=pyhd8ed1ab_1
@@ -56,14 +56,14 @@ dependencies:
   - lcms2=2.17=h717163a_0
   - ld_impl_linux-64=2.43=h712a8e2_4
   - lerc=4.0.0=h0aef613_1
-  - libasprintf=0.23.1=h8e693c7_0
+  - libasprintf=0.24.1=h8e693c7_0
   - libblas=3.9.0=31_h59b9bed_openblas
   - libbrotlicommon=1.1.0=hb9d3cd8_2
   - libbrotlidec=1.1.0=hb9d3cd8_2
   - libbrotlienc=1.1.0=hb9d3cd8_2
   - libcblas=3.9.0=31_he106b2a_openblas
-  - libclang-cpp20.1=20.1.3=default_h1df26ce_0
-  - libclang13=20.1.3=default_he06ed0a_0
+  - libclang-cpp20.1=20.1.4=default_h1df26ce_0
+  - libclang13=20.1.4=default_he06ed0a_0
   - libcups=2.3.3=h4637d8d_4
   - libcurl=8.13.0=h332b0f4_0
   - libdeflate=1.23=h86f0d12_0
@@ -77,7 +77,7 @@ dependencies:
   - libfreetype6=2.13.3=h48d6fc4_1
   - libgcc=14.2.0=h767d61c_2
   - libgcc-ng=14.2.0=h69a702a_2
-  - libgettextpo=0.23.1=h5888daf_0
+  - libgettextpo=0.24.1=h5888daf_0
   - libgfortran=14.2.0=h69a702a_2
   - libgfortran-ng=14.2.0=h69a702a_2
   - libgfortran5=14.2.0=hf1ad2bd_2
@@ -90,8 +90,8 @@ dependencies:
   - libidn2=2.3.8=ha4ef2c3_0
   - libjpeg-turbo=3.1.0=hb9d3cd8_0
   - liblapack=3.9.0=31_h7ac8fdf_openblas
-  - libllvm20=20.1.3=he9d0ab4_0
-  - liblzma=5.8.1=hb9d3cd8_0
+  - libllvm20=20.1.4=he9d0ab4_0
+  - liblzma=5.8.1=hb9d3cd8_1
   - libnghttp2=1.64.0=h161d5f1_0
   - libnsl=2.0.1=hd590300_0
   - libntlm=1.8=hb9d3cd8_0
@@ -102,7 +102,7 @@ dependencies:
   - libpq=17.4=h27ae623_1
   - libsodium=1.0.20=h4ab18f5_0
   - libsqlite=3.49.1=hee588c1_2
-  - libssh2=1.11.1=hf672d98_0
+  - libssh2=1.11.1=hcf80075_0
   - libstdcxx=14.2.0=h8f9b012_2
   - libstdcxx-ng=14.2.0=h4852527_2
   - libtiff=4.7.0=hd9ff511_4
@@ -111,7 +111,7 @@ dependencies:
   - libwebp-base=1.5.0=h851e524_0
   - libxcb=1.17.0=h8a09558_0
   - libxcrypt=4.4.36=hd590300_1
-  - libxkbcommon=1.8.1=hc4a0caf_0
+  - libxkbcommon=1.9.1=h65c71a3_0
   - libxml2=2.13.7=h4bc477f_1
   - libxslt=1.1.39=h76b75d6_0
   - libzlib=1.3.1=hb9d3cd8_2
@@ -127,16 +127,16 @@ dependencies:
   - numpy=2.2.5=py312h72c5963_0
   - openjpeg=2.5.3=h5fbd93e_0
   - openldap=2.6.9=he970967_0
-  - openssl=3.5.0=h7b32b05_0
+  - openssl=3.5.0=h7b32b05_1
   - packaging=25.0=pyh29332c3_1
   - parso=0.8.4=pyhd8ed1ab_1
-  - pcre2=10.44=hba22ea6_2
+  - pcre2=10.44=hc749103_2
   - perl=5.32.1=7_hd590300_perl5
   - pexpect=4.9.0=pyhd8ed1ab_1
   - pickleshare=0.7.5=pyhd8ed1ab_1004
   - pillow=11.1.0=py312h80c1187_0
-  - pip=25.0.1=pyh8b19718_0
-  - pixman=0.44.2=h29eaf8c_0
+  - pip=25.1.1=pyh8b19718_0
+  - pixman=0.46.0=h29eaf8c_0
   - platformdirs=4.3.7=pyh29332c3_0
   - pluggy=1.5.0=pyhd8ed1ab_1
   - prompt-toolkit=3.0.51=pyha770c72_0
@@ -158,7 +158,7 @@ dependencies:
   - qt6-main=6.9.0=h6441bc3_1
   - readline=8.2=h8c095d6_2
   - scipy=1.15.2=py312ha707e6e_0
-  - setuptools=79.0.1=pyhff2d567_0
+  - setuptools=80.1.0=pyhff2d567_0
   - six=1.17.0=pyhd8ed1ab_0
   - stack_data=0.6.3=pyhd8ed1ab_1
   - tk=8.6.13=noxft_h4845f30_101
@@ -168,7 +168,7 @@ dependencies:
   - typing_extensions=4.13.2=pyh29332c3_0
   - tzdata=2025b=h78e105d_0
   - unicodedata2=16.0.0=py312h66e93f0_0
-  - wayland=1.23.1=h3e06ad9_0
+  - wayland=1.23.1=h3e06ad9_1
   - wcwidth=0.2.13=pyhd8ed1ab_1
   - wheel=0.45.1=pyhd8ed1ab_1
   - xcb-util=0.4.1=hb711507_2
@@ -177,7 +177,7 @@ dependencies:
   - xcb-util-keysyms=0.4.1=hb711507_0
   - xcb-util-renderutil=0.3.10=hb711507_0
   - xcb-util-wm=0.4.2=hb711507_0
-  - xkeyboard-config=2.43=hb9d3cd8_0
+  - xkeyboard-config=2.44=hb9d3cd8_0
   - xorg-libice=1.1.2=hb9d3cd8_0
   - xorg-libsm=1.2.6=he73a12e_0
   - xorg-libx11=1.8.12=h4f16b4b_0


### PR DESCRIPTION
`openvscode-server` is not working correctly (#39). Not sure why.
- Extensions don't work correctly in the conda version.
- The binary version from github does not show correctly.

`code-server` is another implementation and it works fine.