### PR TITLE
Update fornax-he and docs links

### DIFF
--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -87,11 +87,10 @@ jobs:
           else
             ENDPOINT="${{ secrets.ECR_ENDPOINT }}"
           fi
+          # Add if needed: '--trigger-ecr --ecr-endpoint $ENDPOINT'
           python scripts/build.py --debug \
               --registry "$REGISTRY" --repository "${{ github.repository }}" \
               --tag $TAG \
-              --ecr-endpoint $ENDPOINT \
-              --trigger-ecr \
               --push "$IMAGES_TO_BUILD"
   
   test-images:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,12 +67,12 @@ jobs:
       - name: Tag main images with release tags
         id: push
         run: |
+          # Add if needed: '--trigger-ecr --ecr-endpoint ${{ secrets.ECR_ENDPOINT }} ${{ secrets.ECR_ENDPOINT_PROD }} \'
           python scripts/build.py --debug --no-build \
               --registry "$REGISTRY" --repository "${{ github.repository }}" \
               --tag "${{ github.event.release.target_commitish }}" \
               --release "${{ github.event.release.tag_name }}" \
-              --ecr-endpoint ${{ secrets.ECR_ENDPOINT }} ${{ secrets.ECR_ENDPOINT_PROD }} \
-              --trigger-ecr --export-lock "${{ matrix.image }}"
+              --export-lock "${{ matrix.image }}"
             
             # pack lock files into a zip file
             zip -r "${{ matrix.image }}-environment-locks.zip" "${{ matrix.image }}_locks"

--- a/fornax-hea/build-ciao.sh
+++ b/fornax-hea/build-ciao.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/bash
+
+# Location of support data
+if [ -z $SUPPORT_DATA_DIR ]; then
+    echo "ERROR: SUPPORT_DATA_DIR not defined"
+    exit 1
+fi
+
+# install ciao; do it in a script instead of yml file so
+# get more control over the spectral data files
+WORKDIR=/tmp/ciao
+mkdir -p $WORKDIR
+cd $WORKDIR
+
+rm -rf * > /dev/null 2>&1
+
+cat <<EOF > conda-ciao.yml
+name: ciao
+channels:
+  - https://cxc.cfa.harvard.edu/conda/ciao
+  - conda-forge
+dependencies:
+  - python=3.11
+  - ciao=4.17
+  - sherpa
+  - ciao-contrib
+  - marx
+  - pytest
+EOF
+
+# Use the yml to create the ciao env
+bash /usr/local/bin/conda-env-install.sh
+
+
+# delete the model data and caldb; create simlinks below
+rm -rf $ENV_DIR/ciao/spectral/modelData
+rm -rf $ENV_DIR/ciao/CALDB | true
+
+# Remove these files
+rm -rf $ENV_DIR/ciao/test
+rm -rf $ENV_DIR/ciao/docs
+
+
+# get ciao version
+CIAO_VERSION=$(micromamba list ciao -p $ENV_DIR/ciao --json | jq -r '.[0].version')
+CALDB_VERSION=$(micromamba list caldb_main -p $ENV_DIR/ciao --json | jq -r '.[0].version')
+
+# link modelData
+ln -sf $SUPPORT_DATA_DIR/ciao-${CIAO_VERSION}/spectral/modelData $ENV_DIR/ciao/spectral/modelData
+# link caldb.
+ln -sf $SUPPORT_DATA_DIR/ciao-caldb-${CIAO_VERSION}/CALDB $ENV_DIR/ciao/CALDB
+
+# clean
+cd $HOME
+rm -rf $WORKDIR

--- a/fornax-hea/build-fermi.sh
+++ b/fornax-hea/build-fermi.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/bash
+
+# Location of support data
+if [ -z $SUPPORT_DATA_DIR ]; then
+    echo "ERROR: SUPPORT_DATA_DIR not defined"
+    exit 1
+fi
+
+# install ciao; do it in a script instead of yml file so
+# get more control over the spectral data files
+WORKDIR=/tmp/fermi
+mkdir -p $WORKDIR
+cd $WORKDIR
+
+rm -rf * > /dev/null 2>&1
+
+cat <<EOF > conda-fermi.yml
+name: fermi
+channels:
+  - fermi
+  - conda-forge
+dependencies:
+  - python=3.11
+  - fermitools=2.4
+  - fermipy
+  - pytest
+EOF
+
+# Use the yml to create the ciao env
+bash /usr/local/bin/conda-env-install.sh
+
+
+# delete data; create simlinks below
+rm -rf $ENV_DIR/fermi/share/fermitools/refdata
+
+# Remove these files
+# none
+
+
+# get fermitools version
+FERMITOOLS_VERSION=$(micromamba list fermitools -p $ENV_DIR/fermi --json | jq -r '.[0].version')
+
+# link data files
+ln -sf $SUPPORT_DATA_DIR/fermitools-${FERMITOOLS_VERSION}/refdata $ENV_DIR/fermi/share/fermitools/refdata
+
+# clean
+cd $HOME
+rm -rf $WORKDIR

--- a/introduction.md
+++ b/introduction.md
@@ -26,6 +26,8 @@ at the start of every new session. To disable these updates, add an empty file c
 
 ## 25.0821
 - Update fornax-labextension to get the updated links.
+- Add ciao and fermitools to the high energy image.
+- Add `/opt/support-data` that points to a sharing location for data used by the software.
 
 ## 25.0714
 - Fix notebook scrolling jumps (caused by jupyterlab-myst) by setting a default windowing mode in the notebook app.

--- a/introduction.md
+++ b/introduction.md
@@ -24,6 +24,9 @@ at the start of every new session. To disable these updates, add an empty file c
 ---
 # Latest Changes
 
+## 25.0821
+- Update fornax-labextension to get the updated links.
+
 ## 25.0714
 - Fix notebook scrolling jumps (caused by jupyterlab-myst) by setting a default windowing mode in the notebook app.
 - Change location of installed software to allow for portability. Lock files are now

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -36,6 +36,9 @@ See the "Actions" tab of the repository to see the results of each workflow.
 
 # Notable Changes
 
+## 08-2025
+- Disable --trigger-ecr in actions as pull-though cache is not working correctly
+
 ## 06-2025
 - Lock files are copied to a single location `$LOCK_DIR`.
 - Lock files are also released with every image release and available as github release assets.


### PR DESCRIPTION
- Update fornax-labextension to get the updated links.
- Add ciao and fermitools to the high energy image.
- Add `/opt/support-data` that points to a sharing location for data used by the software.