### PR TITLE
Adding a build script for XMM SAS to the fornax-hea directory

### DIFF
--- a/fornax-hea/build-sas.sh
+++ b/fornax-hea/build-sas.sh
@@ -25,7 +25,7 @@ rm -rf * > /dev/null 2>&1
 ############# Definition of software versions #############
 ubuntu_version=24.04
 sas_version=22.1.0
-py_version=3.12
+py_version=$PYTHON_VERSION
 ###########################################################
 
 


### PR DESCRIPTION
A build script along the lines of the build-ciao, build-heasoft, and build-fermi scripts has been written, based off the SciServer SAS dockerfile.

It wll download, unpack, install, and relate SAS to a conda environment - activation and deactivation scripts are included to ensure that the correct environment variables are set for SAS use.

Building and installation works when tested by running the build script on the Fornax platform (a 4c/16GB resource request) as a user - though of course the environment and install and not persistent across sessions.

One unsolved problem is that the XMM current calibration files (CCFs) are not being rsynced from the ESA store when running on Fornax itself - no connection can be made. There is a step in the build script that attempts this, as it is written now, but it fail when running on Fornax as a user, and then proceed to the next step.

We may have to add the CCFs to shared-storage in some other way.