### PR TITLE
Use deployed_notebooks orphan branch for notebooks

### DIFF
--- a/fornax-base/update-notebooks.sh
+++ b/fornax-base/update-notebooks.sh
@@ -15,14 +15,21 @@ notebook_repos=(
     https://github.com/nasa-fornax/fornax-demo-notebooks.git
 )
 
+# Branch to pull from, preferably a curated, deployed branch rather than the development default
+deployed_branches=(
+    deployed_notebooks
+)
+
 mkdir -p $NOTEBOOK_DIR
 cd $NOTEBOOK_DIR
 # copy notebooks
 echo "Cloning the notebooks to $NOTEBOOK_DIR ..."
-for repo in ${notebook_repos[@]}; do
+for i in ${!notebook_repos[@]}; do
+    repo=${notebook_repos[i]}
+    branch=${deployed_branches[i]}
     name=`echo $repo | sed 's#.*/\([^/]*\)\.git#\1#'`
     # use nbgitpuller
-    timeout $timeout $JUPYTER_DIR/bin/gitpuller $repo deployed_notebooks $name
+    timeout $timeout $JUPYTER_DIR/bin/gitpuller $repo $branch $name
 done
 
 # TEMPORARY fix for kernel names; remove once fixed upstream

--- a/fornax-base/update-notebooks.sh
+++ b/fornax-base/update-notebooks.sh
@@ -22,7 +22,7 @@ echo "Cloning the notebooks to $NOTEBOOK_DIR ..."
 for repo in ${notebook_repos[@]}; do
     name=`echo $repo | sed 's#.*/\([^/]*\)\.git#\1#'`
     # use nbgitpuller
-    timeout $timeout $JUPYTER_DIR/bin/gitpuller $repo main $name
+    timeout $timeout $JUPYTER_DIR/bin/gitpuller $repo deployed_notebooks $name
 done
 
 # TEMPORARY fix for kernel names; remove once fixed upstream

--- a/fornax-main/build-01-notebook-req.sh
+++ b/fornax-main/build-01-notebook-req.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 # Create environments for the notebooks to run in
 # Download the notebook repo and use the requirement files
-set -e 
+set -e
 set -o pipefail
 
 resolve_references() {
     local file="$1"
-    
+
     while IFS= read -r line; do
         if [[ "$line" =~ ^-r(.+)$ ]]; then
             ref_file="${BASH_REMATCH[1]}"
@@ -20,7 +20,7 @@ resolve_references() {
 }
 
 cd /tmp/
-git clone --depth 1 https://github.com/nasa-fornax/fornax-demo-notebooks.git
+git clone --single-branch --branch deployed_notebooks https://github.com/nasa-fornax/fornax-demo-notebooks
 
 if [ -d build ]; then rm -rf build; fi
 mkdir build
@@ -36,7 +36,7 @@ done
 rm requirements_*
 # pin numpy<2.3; issue: https://github.com/nasa-fornax/fornax-demo-notebooks/issues/431
 sed -i 's/numpy$/numpy<2.3/' requirements-py-ml_agnzoo.txt
-bash /usr/local/bin/uv-env-install.sh 
+bash /usr/local/bin/uv-env-install.sh
 
 cd /tmp/
 rm -rf fornax-demo-notebooks build


### PR DESCRIPTION
This resolves #36 

`deployed_notebooks` is a shallow orphan branch that is updated after merges on the `main` branches, assuming the html builds are passing