### PR TITLE
Update to 25.0903

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,5 +133,4 @@ dmypy.json
 
 # others
 lock_files/
-local_build.sh
 .DS_Store

--- a/fornax-base/Dockerfile
+++ b/fornax-base/Dockerfile
@@ -27,7 +27,7 @@ ENV DEFAULT_ENV=python3 \
     # scripts that rely on support data should use SUPPORT_DATA_DIR
     SUPPORT_DATA_DIR=/opt/support-data \
     # path
-    PATH=$ENV_DIR/base/bin:$PATH:$ENV_DIR/other/code-server/bin \
+    PATH=$ENV_DIR/base/bin:$PATH \
     # For firefly
     FIREFLY_URL=https://irsa.ipac.caltech.edu/irsaviewer \
     # for dask

--- a/fornax-base/base.txt
+++ b/fornax-base/base.txt
@@ -1,6 +1,7 @@
 vim
 nano
 git
+less
 zip
 pandoc
 jq

--- a/fornax-base/jupyter-requirements.txt
+++ b/fornax-base/jupyter-requirements.txt
@@ -5,6 +5,5 @@ jupyterlab-git
 jupyterlab-myst
 jupyter-vscode-proxy
 jupyter_cpu_alive
-nbgitpuller
 dask-labextension
 jupyter-firefly-extensions

--- a/fornax-base/update-notebooks.sh
+++ b/fornax-base/update-notebooks.sh
@@ -38,6 +38,12 @@ for i in ${!notebook_repos[@]}; do
     timeout $timeout $JUPYTER_DIR/bin/gitpuller $repo $branch $name
 done
 
+# TEMPORARY fix for kernel names; remove once fixed upstream
+if $JUPYTER_DIR/bin/jupyter kernelspec list  | grep multiband_photometry; then
+    cd $NOTEBOOK_DIR/fornax-demo-notebooks
+    jupytext --set-kernel py-ztf_ps1_crossmatch crossmatch/ztf_ps1_crossmatch.md
+fi
+
 # bring in the intro page
 if test -f $JUPYTER_DIR/introduction.html && ! test -L $NOTEBOOK_DIR/introduction.html; then
     cp $JUPYTER_DIR/introduction.html $NOTEBOOK_DIR

--- a/fornax-base/update-notebooks.sh
+++ b/fornax-base/update-notebooks.sh
@@ -25,17 +25,22 @@ cd $NOTEBOOK_DIR
 # copy notebooks
 echo "Cloning the notebooks to $NOTEBOOK_DIR ..."
 
-if [ -d fornax-demo-notebooks ]; then
-    # non-linear git history so we start fresh
-    rm -rf fornax-demo-notebooks
-fi
-
 for i in ${!notebook_repos[@]}; do
     repo=${notebook_repos[i]}
     branch=${deployed_branches[i]}
     name=`echo $repo | sed 's#.*/\([^/]*\)\.git#\1#'`
-    # use nbgitpuller
-    timeout $timeout $JUPYTER_DIR/bin/gitpuller $repo $branch $name
+    echo "++++ Updating $name from $repo ..."
+    if [ -d $name ]; then
+        # first ensure we can delete it
+        find $name -type d -exec chmod 755 {} +
+        find $name -type f -exec chmod 644 {} +
+        # now delete
+        rm -rf $name
+    fi
+    # get a fresh clone of the the repo
+    git clone --branch $branch --single-branch --depth 1 $repo
+    rm -rf $name/.git
+    echo "+++++ Done with $name!"
 done
 
 # TEMPORARY fix for kernel names; remove once fixed upstream
@@ -49,7 +54,16 @@ if test -f $JUPYTER_DIR/introduction.html && ! test -L $NOTEBOOK_DIR/introductio
     cp $JUPYTER_DIR/introduction.html $NOTEBOOK_DIR
 fi
 
+# Now make the notebooks folders read-only
+cd $NOTEBOOK_DIR
+for i in ${!notebook_repos[@]}; do
+    repo=${notebook_repos[i]}
+    branch=${deployed_branches[i]}
+    name=`echo $repo | sed 's#.*/\([^/]*\)\.git#\1#'`
 
+    find $name -type f -exec chmod 444 {} +
+    find $name -type d -exec chmod 555 {} +
+done
 
 # reset location
 cd $HOME

--- a/fornax-base/update-notebooks.sh
+++ b/fornax-base/update-notebooks.sh
@@ -39,7 +39,7 @@ for i in ${!notebook_repos[@]}; do
 done
 
 # TEMPORARY fix for kernel names; remove once fixed upstream
-if $JUPYTER_DIR/bin/jupyter kernelspec list  | grep multiband_photometry; then
+if $JUPYTER_DIR/bin/jupyter kernelspec list  | grep ztf_ps1_crossmatch; then
     cd $NOTEBOOK_DIR/fornax-demo-notebooks
     jupytext --set-kernel py-ztf_ps1_crossmatch crossmatch/ztf_ps1_crossmatch.md
 fi

--- a/fornax-base/update-notebooks.sh
+++ b/fornax-base/update-notebooks.sh
@@ -24,6 +24,12 @@ mkdir -p $NOTEBOOK_DIR
 cd $NOTEBOOK_DIR
 # copy notebooks
 echo "Cloning the notebooks to $NOTEBOOK_DIR ..."
+
+if [ -d fornax-demo-notebooks ]; then
+    # non-linear git history so we start fresh
+    rm -rf fornax-demo-notebooks
+fi
+
 for i in ${!notebook_repos[@]}; do
     repo=${notebook_repos[i]}
     branch=${deployed_branches[i]}
@@ -31,12 +37,6 @@ for i in ${!notebook_repos[@]}; do
     # use nbgitpuller
     timeout $timeout $JUPYTER_DIR/bin/gitpuller $repo $branch $name
 done
-
-# TEMPORARY fix for kernel names; remove once fixed upstream
-if $JUPYTER_DIR/bin/jupyter kernelspec list  | grep multiband_photometry; then
-    cd $NOTEBOOK_DIR/fornax-demo-notebooks
-    jupytext --set-kernel py-light_curve_collector light_curves/light_curve_collector.md
-fi
 
 # bring in the intro page
 if test -f $JUPYTER_DIR/introduction.html && ! test -L $NOTEBOOK_DIR/introduction.html; then

--- a/fornax-slim/Dockerfile
+++ b/fornax-slim/Dockerfile
@@ -81,7 +81,7 @@ ENV DEFAULT_ENV=python3 \
     # scripts that rely on support data should use SUPPORT_DATA_DIR
     SUPPORT_DATA_DIR=/opt/support-data \
     # path
-    PATH=$ENV_DIR/base/bin:$PATH:$ENV_DIR/other/code-server/bin \
+    PATH=$ENV_DIR/base/bin:$PATH \
     # For firefly
     FIREFLY_URL=https://irsa.ipac.caltech.edu/irsaviewer \
     # for dask

--- a/introduction.md
+++ b/introduction.md
@@ -21,8 +21,9 @@ terminal.
 ---
 # Latest Changes
 
-## 25.0902 (dev)
-- Rebuild to pick the new deployed notebook kernels: ztf_ps1_crossmatch and spectra_collector
+## 25.0902
+- Rebuild to pick the new deployed notebook kernels: ztf_ps1_crossmatch and spectra_collector.
+- Bug fixes (issues #87, #86).
 
 ## 25.0829
 - Add 'Update Notebooks' to Fornax menu (fornax-labextension = 0.1.5).

--- a/introduction.md
+++ b/introduction.md
@@ -21,6 +21,9 @@ terminal.
 ---
 # Latest Changes
 
+## 25.0902 (dev)
+- Rebuild to pick the new deployed notebook kernels: ztf_ps1_crossmatch and spectra_collector
+
 ## 25.0829
 - Add 'Update Notebooks' to Fornax menu (fornax-labextension = 0.1.5).
 - Fix Firefly and dask installations.

--- a/introduction.md
+++ b/introduction.md
@@ -21,8 +21,9 @@ terminal.
 ---
 # Latest Changes
 
-## 25.0902
+## 25.0903
 - Rebuild to pick the new deployed notebook kernels: ztf_ps1_crossmatch and spectra_collector.
+- Make the fornax-notebooks read-only. Modified notebooks needs to be saved elsewhere.
 - Bug fixes (issues #87, #86).
 
 ## 25.0829

--- a/introduction.md
+++ b/introduction.md
@@ -22,8 +22,8 @@ terminal.
 # Latest Changes
 
 ## 25.0903
-- Rebuild to pick the new deployed notebook kernels: ztf_ps1_crossmatch and spectra_collector.
-- Make the fornax-notebooks read-only. Modified notebooks needs to be saved elsewhere.
+- Rebuild to pick the new deployed notebook kernels: `ztf_ps1_crossmatch` and `spectra_collector`.
+- Make the fornax-notebooks read-only. Modified notebooks need to be saved elsewhere.
 - Bug fixes (issues #87, #86).
 
 ## 25.0829

--- a/local_build.sh
+++ b/local_build.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/bash
+
+action=$1
+image=$2
+tag=$3
+
+if test -z $action || test -z $image; then
+    echo "USAGE: $0 build|run image tag?"
+    exit 1
+fi
+
+if test $action != "build" && test $action != "run"; then
+    echo "ERROR: Unknown action $action. action needs to be either build or run"
+    exit 1
+fi
+
+if test $action == "run" && test -z $tag; then 
+    echo "ERROR: with action=run, a tag is needed; $0 build|run image tag"
+    exit 1
+fi
+
+if test ! -d ./$image; then
+    echo "ERROR: Unknown image $image."
+    exit 1
+fi
+
+echo "========================"
+echo "${action}ing $image:$tag"
+echo "========================"
+
+
+if test $action == "build"; then
+    python scripts/build.py --extra-pars="--network=host" $image
+fi
+
+if test $action == "run"; then
+    docker run -it --rm --network=host -v .:/tmp/code ghcr.io/nasa-fornax/fornax-images/$image:$tag bash
+fi

--- a/scripts/builder.py
+++ b/scripts/builder.py
@@ -305,7 +305,7 @@ class Builder(TaskRunner):
             if source_tag == 'main' and 'stable' not in release_tags:
                 release_tags.append('stable')
 
-            if export_lock:
+            if export_lock and image in ['fornax-main', 'fornax-hea']:
                 self.export_lockfiles(image, source_tag)
 
             # loog through release tags

--- a/tests/test_fornax_main.py
+++ b/tests/test_fornax_main.py
@@ -79,6 +79,8 @@ def test_imports(notebook):
     py_filename = nb_filename.replace('md', 'py')
     # isolate the imports
     with change_dir(f'{notebook_dir}/{nb_path}'):
+        # we need the folder to be writable
+        os.system('chmod -R 755 .')
         CommonTests.run_cmd(
             f'jupytext --to py {nb_filename}'
         )


### PR DESCRIPTION
- Rebuild to pick the new deployed notebook kernels: `ztf_ps1_crossmatch` and `spectra_collector`.
- Make the fornax-notebooks read-only. Modified notebooks need to be saved elsewhere.
- Bug fixes (issues #87, #86).