### PR TITLE
Fix indentation for boto3 in build-sas.sh

### DIFF
--- a/fornax-hea/build-sas.sh
+++ b/fornax-hea/build-sas.sh
@@ -107,7 +107,7 @@ dependencies:
     - astroquery
     - astropy
     - s3fs
-	- boto3
+    - boto3
 EOF
 
 # Use the yml to create the SAS env


### PR DESCRIPTION
When adding boto3 to the build-sas.sh conda environment requirements, I must have added a tab rather than four spaces, and that breaks the SAS installation quite thoroughly, because the conda environment creation apparently can't handle it, which then means that there is nowhere for SAS to be installed into.