### PR TITLE
Added uncompresspy to the modules installed in HEASoft environment

### DIFF
--- a/fornax-hea/build-heasoft.sh
+++ b/fornax-hea/build-heasoft.sh
@@ -30,6 +30,7 @@ channels:
 dependencies:
   - python=$PYTHON_VERSION
   - heasoft=6.36.*
+  - uncompresspy
   - pip
   - pip:
     - pytest


### PR DESCRIPTION
This is an optional dependency of Astropy, used for opening fits files that have been compressed using 'Zlib'. This is relevant for the use of ROSAT data in Python, as most of the files in that part of our archive are compressed with Zlib.