### PR TITLE
Prepare for 26.0401 release

### DIFF
--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -42,6 +42,12 @@ jobs:
       
       - uses: ./.github/actions/clean-storage
 
+      - name: Check links in the intro page
+        uses: lycheeverse/lychee-action@v1
+        with:
+          args: "introduction.md"
+          fail: true
+
       - name: Setup Python
         uses: actions/setup-python@v5
         id: setup_python

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,15 @@ jobs:
       images: ${{ steps.image-list.outputs.IMAGE_LIST }}
 
     steps:
+      - name: Check source branch is main
+        run: |
+          if [ "${{ github.ref_name }}" != "main" ]; then
+            echo "❌ Releases must be created from main branch."
+            echo "    Current ref: ${{ github.ref_name }}"
+            exit 1
+          fi
+          echo "✅ Branch check passed."
+      
       - name: Checkout repository
         uses: actions/checkout@v4
     

--- a/changes.md
+++ b/changes.md
@@ -1,5 +1,12 @@
 # Latest Changes
 
+## 26.0401
+- Update fornax-labextension to 0.1.17, which includes:
+  - Absorb jupyter_cpu_alive
+  - Style changes for the launcher.
+  - Disable terminal culling when a there CPU activity.
+- Install jdaviz in the main jupyter environment.
+
 ## 26.0302
 - Add tex processing with tectonic and enable exporting notebooks as pdf.
 - Add the environment for SPHEREx Source Discovery Tool.

--- a/fornax-base/jupyter-requirements.txt
+++ b/fornax-base/jupyter-requirements.txt
@@ -4,8 +4,8 @@ jupyter-resource-usage
 jupyterlab-git
 jupyterlab-myst
 jupyter-vscode-proxy
-jupyter_cpu_alive
 dask-labextension
 jupyter-firefly-extensions
+jdaviz
 pip
 # notebook-intelligence

--- a/fornax-base/parse_nb_manifest.py
+++ b/fornax-base/parse_nb_manifest.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 import re
+import yaml
+from yaml import Loader
 
 
 manifests = {
@@ -9,7 +11,7 @@ manifests = {
     },
     'irsa': {
         'folder': 'irsa-tutorials',
-        'manifest': 'notebook_manifest_descriptions.txt',
+        'manifest': 'notebook_metadata.yml',
     },
     'heasarc': {
         'folder': 'heasarc-tutorials',
@@ -50,11 +52,21 @@ class Parser:
     
     def parse_irsa(manifest):
         """Parse IRSA manifest"""
+        dir_name = manifests['irsa']['folder']
         with open(manifest) as fp:
-            lines = fp.readlines()
-        # remove the extra level
-        lines = [line.replace('irsa-tutorials/', '') for line in lines]
-        return Parser.std_parse(lines, 'irsa')
+            desc = yaml.load(fp, Loader=Loader)
+        nb_desc = {}
+        for nb in desc:
+            section = nb['section']
+            path = nb['file'].replace('tutorials/', '')
+            description = nb['description']
+            title = nb['title']
+            if section not in nb_desc:
+                nb_desc[section] = []
+            nb_desc[section].append(f'   - [{title}]({dir_name}/{path}): {description}')
+
+        md_desc = '\n'.join([f'- {cat}:\n' + ('\n'.join(vals)) for cat, vals in nb_desc.items()])
+        return md_desc
 
     
     def parse_heasarc(manifest):


### PR DESCRIPTION
- Update fornax-labextension to 0.1.17, which includes:
  - Absorb jupyter_cpu_alive
  - Style changes for the launcher.
  - Disable terminal culling when a there CPU activity.
- Install jdaviz in the main jupyter environment.