### PR TITLE
Added the jupyter bokeh plugin to the fornax-jupyter environment

### DIFF
--- a/fornax-jupyter/jupyter-deps.txt
+++ b/fornax-jupyter/jupyter-deps.txt
@@ -12,4 +12,5 @@ https://heasarc.gsfc.nasa.gov/azoghbi/pip/fviewer_labextension.tar.gz
 https://heasarc.gsfc.nasa.gov/azoghbi/pip/xspec_extension.tar.gz
 https://heasarc.gsfc.nasa.gov/azoghbi/pip/fornax_labextension.tar.gz
 pip
+jupyter_bokeh
 # notebook-intelligence


### PR DESCRIPTION
This is to save having to install it every time I want to run the multi-archive visualization Fornax notebook.

The only change is adding jupyter_bokeh as a dependency for the fornax-jupyter image.