### PR TITLE
Fixed problems in fermi environment that made fermipy unusable

### DIFF
--- a/env-fermi/build-fermi.sh
+++ b/env-fermi/build-fermi.sh
@@ -22,13 +22,15 @@ rm -rf * > /dev/null 2>&1
 
 # TODO IF UPDATING, CHECK WHETHER 'gammapy' HAS A RELEASE VERSION HIGHER THAN 2.1, IF
 #  YES THEN YOU CAN PROBABLY REMOVE THE REGION<0.12 RESTRICTION.
+# TODO Python=3.11 is driven by fermitools, once it has non-dev conda releases
+#  built for versions later than 3.11 this should be replaced by 'python=$PYTHON_VERSION'
 cat <<EOF > conda-fermi.yml
 name: fermi
 channels:
   - fermi
   - conda-forge
 dependencies:
-  - python=$PYTHON_VERSION
+  - python=3.11
   - regions<0.12
   - fermitools
   - fermipy

--- a/env-fermi/build-fermi.sh
+++ b/env-fermi/build-fermi.sh
@@ -20,6 +20,8 @@ cd $WORKDIR
 
 rm -rf * > /dev/null 2>&1
 
+# TODO IF UPDATING, CHECK WHETHER 'gammapy' HAS A RELEASE VERSION HIGHER THAN 2.1, IF
+#  YES THEN YOU CAN PROBABLY REMOVE THE REGION<0.12 RESTRICTION.
 cat <<EOF > conda-fermi.yml
 name: fermi
 channels:
@@ -27,6 +29,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.11
+  - regions<0.12
   - fermitools=2.4
   - fermipy
   - pip

--- a/env-fermi/build-fermi.sh
+++ b/env-fermi/build-fermi.sh
@@ -28,9 +28,9 @@ channels:
   - fermi
   - conda-forge
 dependencies:
-  - python=3.11
+  - python=$PYTHON_VERSION
   - regions<0.12
-  - fermitools=2.4
+  - fermitools
   - fermipy
   - pip
   - pip:

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -8,7 +8,7 @@ import time
 import argparse
 import subprocess
 from datetime import datetime
-
+from subprocess import CalledProcessError
 
 DEFAULT_REPO = "ghcr.io/nasa-fornax/fornax-images"
 IMAGE_ORDER = (
@@ -86,15 +86,25 @@ class Builder:
         self.print(command, logging.INFO)
         result = None
         if not self.dryrun:
-            result = subprocess.run(
-                command,
-                shell=True,
-                check=True,
-                text=True,
-                capture_output=True,
-                timeout=timeout,
-                **runargs,
-            )
+            try:
+                result = subprocess.run(
+                    command,
+                    shell=True,
+                    check=True,
+                    text=True,
+                    capture_output=True,
+                    timeout=timeout,
+                    **runargs,
+                )
+            # Catch the error that will be raised if there is a non-zero exit code
+            # Only because the errors raised are completely unhelpful in actually
+            #  tracking the problem down.
+            except CalledProcessError as proc_err:
+                print(f"Error Code: {proc_err.returncode}")
+                print(f"Stderr: {proc_err.stderr}")
+                # Re-raise the error
+                raise
+
         return result
 
     def setup_logger(self):


### PR DESCRIPTION
## Issues in the fermi environment
There were package version issues in the fermi environment that caused the fermipy package to be non-functional, unable to import its main class. Problems were caused by:
- Current versions of gammapy import a function from the regions module that was removed from its latest release (0.12), this should be fixed in the next release of gammapy (from the looks of the repo anyway), but until then regions is pinned to <0.12.
- Healpy (a fermipy dependency) failing to import because it was trying to import 'trapz' from scipy, which was renamed 'trapezoid' quite a few scipy versions ago. This was because we had a quite old healpy version in the environment, as the fermitools release was pinned at 2.41.

Still can't increase the Python version from 3.11, as mentioned in issue #184, but should be possible soon-ish.


## Other change

Altered the build.py file to display the stderr when failures occur in processes started by subprocess.run in the run() method of Builder - as it was the error just displays the exit code without any extra information, making it impossible to diagnose problems. Now that error is caught, the stderr displayed, and then the error is re-raised.