### PR TITLE
Update repository URL for mast notebooks

### DIFF
--- a/fornax-base/scripts/clone-notebooks.sh
+++ b/fornax-base/scripts/clone-notebooks.sh
@@ -25,7 +25,7 @@ case "$choice" in
         branch="deploy_to_fornax"
         ;;
     mast)
-        repo="https://github.com/sedonaprice/mast_notebooks.git"
+        repo="https://github.com/spacetelescope/mast_notebooks.git"
         branch="deploy_to_fornax"
         ;;
     heasarc)


### PR DESCRIPTION
The MAST notebooks Fornax deployment branch, containing the subset of notebooks selected for inclusion in Fornax, is now available from the main MAST notebooks repository.

This PR updates the repo link for the Fornax notebook clone script.